### PR TITLE
Support wire reads

### DIFF
--- a/actor.js
+++ b/actor.js
@@ -1,23 +1,27 @@
-import { registerType } from './wire';
+import { registerType, TypeString, TypeVarArray, TypeByte } from './wire';
 
 function parseAddress(address) {
-    if (typeof address == 'string') {
-        if (address.startsWith('0x')) {
-            address = address.slice(2);
-        }
-
-        return new Buffer(address, 'hex')
+  if (typeof address == 'string') {
+    if (address.startsWith('0x')) {
+      address = address.slice(2);
     }
 
-    return new Buffer(address);
+    return new Buffer(address, 'hex');
+  }
+
+  return new Buffer(address);
 }
 
 export default class Actor {
-    constructor(address, app = 'sigs', chainId = '') {
-        this.chainId = chainId;
-        this.app = app;
-        this.address = parseAddress(address);
-    }
+  constructor(address, app = 'sigs', chainId = '') {
+    this.chainId = chainId;
+    this.app = app;
+    this.address = parseAddress(address);
+  }
 }
 
-registerType(Actor, ['chainId', 'app', 'address'], 0x00);
+registerType(Actor, [
+  ['chainId', TypeString],
+  ['app', TypeString],
+  ['address', TypeVarArray(TypeByte)],
+], 0x00);

--- a/actor.js
+++ b/actor.js
@@ -1,10 +1,22 @@
 import { registerType } from './wire';
 
+function parseAddress(address) {
+    if (typeof address == 'string') {
+        if (address.startsWith('0x')) {
+            address = address.slice(2);
+        }
+
+        return new Buffer(address, 'hex')
+    }
+
+    return new Buffer(address);
+}
+
 export default class Actor {
     constructor(address, app = 'sigs', chainId = '') {
         this.chainId = chainId;
         this.app = app;
-        this.address = new Buffer(address);
+        this.address = parseAddress(address);
     }
 }
 

--- a/client.js
+++ b/client.js
@@ -1,5 +1,6 @@
 import { Client as RPCClient } from 'rpc-websockets';
 import { Writer, writeObject } from './wire';
+import { hexToBytes } from './util';
 
 function encodeBytes(bytes) {
   return bytes.toString('base64');
@@ -71,9 +72,10 @@ export default class Client {
     return res.data;
   }
 
-  state(key) {
+  async state(key) {
     const encKey = encodeURIComponent(encodeBytes(key));
-    return this._proxyReq(`/state/${encKey}`);
+    const resp = await this._proxyReq(`/state/${encKey}`);
+    return hexToBytes(resp.data);
   }
 
   async _proxyReq(path) {

--- a/signature.js
+++ b/signature.js
@@ -1,8 +1,12 @@
 import nacl from 'tweetnacl';
 import ripemd160 from 'ripemd160';
-import { Writer, writeObject, registerType } from './wire';
+import { Writer, writeObject, registerType, TypeArray, TypeByte } from './wire';
 
 const typeEd25519 = 0x01;
+
+export const signatureLength = nacl.sign.signatureLength;
+export const privateKeyLength = nacl.sign.privateKeyLength;
+export const publicKeyLength = nacl.sign.publicKeyLength;
 
 export class SignatureEd25519 {
     constructor(inner) {
@@ -10,7 +14,9 @@ export class SignatureEd25519 {
     }
 }
 
-registerType(SignatureEd25519, ['inner'], typeEd25519);
+registerType(SignatureEd25519, [
+    ['inner', TypeArray(TypeByte, signatureLength)],
+], typeEd25519);
 
 export class PubKeyEd25519 {
     constructor(inner) {
@@ -18,7 +24,9 @@ export class PubKeyEd25519 {
     }
 }
 
-registerType(PubKeyEd25519, ['inner'], typeEd25519);
+registerType(PubKeyEd25519, [
+    ['inner', TypeArray(TypeByte, publicKeyLength)],
+], typeEd25519);
 
 export function genPrivKey() {
     const pair = nacl.sign.keyPair();
@@ -27,7 +35,7 @@ export function genPrivKey() {
 
 export function sign(msg, privKey) {
     const sigMsg = nacl.sign(msg, privKey);
-    const sig = sigMsg.slice(0, nacl.sign.signatureLength);
+    const sig = sigMsg.slice(0, signatureLength);
     return new SignatureEd25519(sig);
 }
 

--- a/util.js
+++ b/util.js
@@ -41,10 +41,12 @@ export class Writer {
   }
 
   write(str) {
-    this.offset += this.buf.write(str);
+    this.ensureBuf(str.length * 2);
+    this.offset += this.buf.write(str, this.offset);
   }
 
   writeUInt8(b) {
+    this.ensureBuf(1);
     this.offset = this.buf.writeUInt8(b, this.offset);
   }
 

--- a/util.js
+++ b/util.js
@@ -26,3 +26,29 @@ export function hexToBytes(str) {
   
   return new Uint8Array(a);
 }
+
+export class Writer {
+  constructor(capacity) {
+    this.buf = new Buffer(capacity);
+    this.offset = 0;
+  }
+
+  ensureBuf(needBytes) {
+    if (this.buf.length < this.offset + needBytes) {
+      var newBuf = new Buffer(this.buf.length + 1024);
+      this.buf = Buffer.concat([this.buf, newBuf]);
+    }
+  }
+
+  write(str) {
+    this.offset += this.buf.write(str);
+  }
+
+  writeUInt8(b) {
+    this.offset = this.buf.writeUInt8(b, this.offset);
+  }
+
+  get buffer() {
+    return this.buf.slice(0, this.offset);
+  }
+}

--- a/wire.js
+++ b/wire.js
@@ -1,11 +1,155 @@
 export { Reader, Writer } from './js-wire';
 
-const unexportedType = 0x00;
+export const TypeNull = {
+    write(writer, val) {
+        writer.writeUint8(0);
+    },
+    read(reader) {
+        const val = reader.readUint8();
+        if (val !== 0) {
+            throw 'expected null byte';
+        }
+
+        return null;
+    },
+};
+
+export const TypeByte = {
+    write(writer, val) {
+        writer.writeUint8(val);
+    },
+    read(reader) {
+        return reader.readUint8();
+    },
+};
+
+export const TypeBoolean = {
+    write(writer, val) {
+        writer.writeUint8(val ? 1 : 0);
+    },
+    read(reader) {
+        const val = reader.readUint8();
+        if (val === 1) {
+            return true;
+        } else if (val === 0) {
+            return false;
+        }
+
+        throw 'expected boolean';
+    }
+};
+
+export const TypeInteger = {
+    write(writer, val) {
+        writer.writeUint32(val);
+    },
+    read(reader) {
+        return reader.readUint32();
+    },
+};
+
+export const TypeString = {
+    write(writer, val) {
+        writer.writeString(val);
+    },
+    read(reader) {
+        return reader.readString();
+    },
+};
+
+export const TypeArray = function(hint, size) {
+    return {
+        write(writer, val) {
+            if (val.length != size) {
+                throw 'unexpected array size';
+            }
+            for (let i = 0; i < val.length; i++) {
+                writeObject(writer, val[i], hint);
+            }
+        },
+        read(reader) {
+            const arr = [];
+            for (let i = 0; i < size; i++) {
+                arr.push(readObject(reader, hint));
+            }
+
+            if (hint === TypeByte) {
+                return Uint8Array(arr);
+            }
+
+            return arr;
+        },
+    }
+};
+
+export const TypeVarArray = function(hint) {
+    return {
+        write(writer, val) {
+            writer.writeUvarint(val.length);
+            for (let i = 0; i < val.length; i++) {
+                writeObject(writer, val[i], hint);
+            }
+        },
+        read(reader) {
+            const size = reader.readUvarint();
+            const arr = [];
+            for (let i = 0; i < size; i++) {
+                arr.push(readObject(reader, hint));
+            }
+
+            if (hint === TypeByte) {
+                return Buffer(arr);
+            }
+
+            return arr;
+        },
+    }
+};
+
+export const TypeStruct = function(baseType, fields, id) {
+    return {
+        write(writer, val) {
+            if (id) {
+                writer.writeUint8(id);
+            }
+            fields.forEach(field => {
+                writeObject(writer, val[field.name], field.type);
+            });
+        },
+        read(reader) {
+            if (id) {
+                const typeId = reader.readUint8() || undefined;
+                if (typeId !== id) {
+                    throw 'expecting different type id';
+                }
+            }
+
+            const obj = Object.create(baseType.prototype);
+            fields.forEach(field => {
+                obj[field.name] = readObject(reader, field.type);
+            });
+
+            return obj;
+        },
+    }
+};
 
 const typeRegistry = new Map();
 
-export function registerType(type, fields, id) {
-    typeRegistry.set(type, {'id': id, 'fields': fields});
+function normField(field) {
+    if (typeof field == 'string') {
+        return { name: field };
+    }
+
+    if (Array.isArray(field)) {
+        return { name: field[0], type: field[1] };
+    }
+
+    return field;
+}
+
+export function registerType(baseType, fields, id) {
+    typeRegistry.set(baseType, TypeStruct(baseType, fields.map(normField), id));
 }
 
 function findTypeEntry(obj) {
@@ -18,58 +162,50 @@ function findTypeEntry(obj) {
     throw 'no entry found';
 }
 
-function writeBytes(writer, bytes) {
-    for (var i = 0; i < bytes.length; i++) {
-        writer.writeUint8(bytes[i]);
-    }
-}
-
-function writeNull(writer) {
-    writer.writeUint8(0);
-}1
-
-function writeType(writer, type) {
-    writer.writeUint8(type);
-}
-
-export function writeObject(writer, obj) {
-    switch(typeof obj) {
-        case 'undefined':
-            writeNull(writer);
-            break;
-        case 'string':
-            writer.writeString(obj);
-            break;
-        case 'boolean':
-            obj ? writer.writeUint8(1) : writer.writeUint8(0);
-            break;
-        case 'number':
-            writer.writeUint32(obj);
-            break;
-        case 'object':
-            if (Array.isArray(obj)) {
-                writer.writeUvarint(obj.length);
-                obj.forEach(val => {
-                    writeObject(writer, val);
-                })
-            } else if (obj instanceof Buffer) {
-                writer.writeUvarint(obj.length);
-                writeBytes(writer, obj);
-            } else if (obj instanceof Uint8Array) {
-                writeBytes(writer, obj);
-            } else {
-                const entry = findTypeEntry(obj);
-                if (entry.id !== unexportedType) {
-                    writeType(writer, entry.id);
-                }
-                entry.fields.forEach(field => {
-                    writeObject(writer, obj[field]);
-                });
-            }
-            break;
-        default:
-            throw 'unknown obj type';
+function findTypeEntryById(id) {
+    for (let [type, entry] of typeRegistry) {
+        if (type.id === id) {
+            return entry;
+        }
     }
 
+    throw 'no entry found';
+}
+
+function detType(obj) {
+    const type = {
+        'undefined': TypeNull,
+        'string': TypeString,
+        'boolean': TypeBoolean,
+        'number': TypeInteger,
+    }[typeof obj];
+
+    if (type) {
+        return type;
+    }
+
+    if (Array.isArray(obj)) {
+        return TypeVarArray();
+    }
+
+    if (obj instanceof Buffer) {
+        return TypeVarArray(TypeByte);
+    }
+
+    if (obj instanceof Uint8Array) {
+        return TypeArray(TypeByte);
+    }
+
+    return findTypeEntry(obj);
+}
+
+export function writeObject(writer, obj, typeHint) {
+    const type = typeHint || detType(obj);
+    type.write(writer, obj);
     return writer;
+}
+
+export function readObject(reader, type) {
+    type = typeRegistry.get(type) || type;
+    return type.read(reader);
 }

--- a/wire.test.js
+++ b/wire.test.js
@@ -1,0 +1,40 @@
+import test from 'tape';
+
+import {
+  TypeString,
+  TypeVarArray,
+  TypeByte,
+  TypeStruct,
+  Reader,
+  Writer,
+  readObject,
+  writeObject,
+  registerType,
+ } from './wire';
+
+export default class Actor {
+  constructor(address, app = 'sigs', chainId = '') {
+    this.chainId = chainId;
+    this.app = app;
+    this.address = address;
+  }
+}
+
+test('encode and decode wire', (assert) => {
+  registerType(Actor, [
+    ['chainId', TypeString],
+    ['app', TypeString],
+    ['address', TypeVarArray(TypeByte)],
+  ], 0x01);
+
+  const actor = new Actor(new Buffer([1, 2, 3]), 'foo', 'bar');
+
+  const w = new Writer();
+  writeObject(w, actor);
+
+  const r = new Reader(w.getBuffer());
+  const obj = readObject(r, Actor)
+
+  assert.deepEqual(actor, obj);
+  assert.end();
+})


### PR DESCRIPTION
- Refactor wire code to be more flexible, have stronger typing, and support reads
- Add generic buffer utility class that can be used to build binary blobs
- Add `nonce` and `state` methods for fetching application state