### PR TITLE
Add ability to subscribe to contract events via WebSocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "crypto-browserify": "^3.12.0",
     "google-protobuf": "^3.5.0",
     "ripemd160": "^2.0.1",
-    "rpc-websockets": "^3.6.1",
+    "rpc-websockets": "^4.1.1",
     "tweetnacl": "^1.0.0"
   },
   "devDependencies": {

--- a/src/address.ts
+++ b/src/address.ts
@@ -18,6 +18,11 @@ export class LocalAddress {
     )
   }
 
+  equals(other: LocalAddress): boolean {
+    // Node API docs say parameters can be Buffer | Uint8Array... so shush TypeScript
+    return Buffer.compare(this.bytes as Buffer, other.bytes as Buffer) === 0
+  }
+
   static fromHexString(hexAddr: string): LocalAddress {
     if (!hexAddr.startsWith('0x')) {
       throw new Error('hexAddr argument has no 0x prefix')
@@ -60,6 +65,10 @@ export class Address {
     addr.setChainId(this.chainId)
     addr.setLocal(bufferToProtobufBytes(this.local.bytes))
     return addr
+  }
+
+  equals(other: Address): boolean {
+    return this.chainId === other.chainId && this.local.equals(other.local)
   }
 
   static UmarshalPB(pb: pb.Address): Address {

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,15 +31,31 @@ export enum ClientEvent {
   Contract = 'contractEvent'
 }
 
+/**
+ * Generic event emitted by smart contracts.
+ */
 export interface IChainEventArgs {
+  // Address of the contract that emitted the event.
   contractAddress: Address
+  // Address of the caller that caused the event to be emitted.
   callerAddress: Address
   blockHeight: string
+  // The data emitted by the smart contract, the format and structure is defined by that contract.
   data: Uint8Array
 }
 
 /**
  * Writes to & reads from a Loom DAppChain.
+ *
+ * The client can listen to events emitted by smart contracts running on a DAppChain,
+ * there is currently only one type of event. The event subscription API matches the NodeJS
+ * EventEmitter API. For example...
+ *
+ * function subscribeToEvents(client: Client) {
+ *   client.on(ClientEvent.Contract, (event: IChainEventArgs) => {
+ *     // handle event
+ *   }
+ * }
  */
 export class Client extends EventEmitter {
   public readonly chainId: string

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -19,6 +19,18 @@ import { bufferToProtobufBytes } from './crypto-utils'
  * The Contract class streamlines interaction with a contract that was deployed on a Loom DAppChain.
  * Each instance of this class is bound to a specific contract, and provides a simple way of calling
  * into and querying that contract.
+ *
+ * A contract instance can be used to listen to events emitted by the corresponding smart contract,
+ * there is currently only one type of event. The event subscription API matches the NodeJS
+ * EventEmitter API. For example...
+ *
+ * function subscribeToEvents(contract: Contract) {
+ *   contract.on(Contract.EVENT, (event: IChainEventArgs) => {
+ *     const dataStr = Buffer.from(event.data as Buffer).toString('utf8')
+ *     const dataObj = JSON.parse(dataStr)
+ *     console.log('Contract Event: ' + dataStr)
+ *   })
+ * }
  */
 export class Contract extends EventEmitter {
   static readonly EVENT = 'event'

--- a/src/evm-contract.ts
+++ b/src/evm-contract.ts
@@ -10,6 +10,10 @@ import { Address } from './address'
  * deployed on a Loom DAppChain EVM.
  * Each instance of this class is bound to a specific contract, and provides a simple way of calling
  * into and querying that contract.
+ *
+ * A contract instance can be used to listen to events emitted by the corresponding smart contract,
+ * there is currently only one type of event. The event subscription API matches the NodeJS
+ * EventEmitter API.
  */
 export class EvmContract extends EventEmitter {
   static readonly EVENT = 'event'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Client, ITxMiddlewareHandler } from './client'
+export { Client, IChainEventArgs, ITxMiddlewareHandler } from './client'
 export { Contract } from './contract'
 export { EvmContract } from './evm-contract'
 export { Address, LocalAddress } from './address'

--- a/src/internal/ws-rpc-client.ts
+++ b/src/internal/ws-rpc-client.ts
@@ -1,4 +1,20 @@
 import { Client as WSClient } from 'rpc-websockets'
+import { EventEmitter } from 'events'
+
+export interface IEventData {
+  caller: {
+    ChainID: string
+    Local: string
+  }
+  address: {
+    ChainID: string
+    Local: string
+  }
+  blockHeight: string
+  encodedData: string
+}
+
+export type WSRPCClientEventListener = (eventArgs: IEventData) => void
 
 /**
  * Sends JSON-RPC messages via web sockets.
@@ -7,6 +23,7 @@ export class WSRPCClient {
   private _client: WSClient
   private _openPromise?: Promise<void>
   private _rpcId: number = 0
+  private _subscribers: Array<WSRPCClientEventListener> = []
 
   private _getNextRequestId = () => (++this._rpcId).toString()
 
@@ -20,6 +37,7 @@ export class WSRPCClient {
       generateRequestId?: (method: string, params: object | any[]) => string
     } = {}
   ) {
+    this._onEventMessage = this._onEventMessage.bind(this)
     this._client = new WSClient(
       url,
       {
@@ -66,5 +84,46 @@ export class WSRPCClient {
     await this._ensureConnectionAsync()
     console.log(`Sending RPC msg to ${this.url}, method ${method}`)
     return this._client.call<T>(method, params)
+  }
+
+  async subscribeAsync(listener: WSRPCClientEventListener): Promise<void> {
+    if (this._subscribers.indexOf(listener) !== -1) {
+      return
+    }
+    this._subscribers.push(listener)
+    if (this._subscribers.length === 1) {
+      // rpc-websockets is just going to throw away the event messages from the DAppChain because
+      // they don't conform to it's idea of notifications or events... fortunately few things in
+      // javascript are truly private... so we'll just handle those event message ourselves ;)
+      ;((this._client as any).socket as EventEmitter).on('message', this._onEventMessage)
+    }
+    await this.sendAsync('subevents', {})
+  }
+
+  async unsubscribeAsync(listener: WSRPCClientEventListener): Promise<void> {
+    const idx = this._subscribers.indexOf(listener)
+    if (idx !== -1) {
+      this._subscribers.splice(idx, 1)
+    }
+    if (this._subscribers.length === 0) {
+      ;((this._client as any).socket as EventEmitter).removeListener(
+        'message',
+        this._onEventMessage
+      )
+      await this.sendAsync('unsubevents', {})
+    }
+  }
+
+  private _onEventMessage(message: string | ArrayBuffer) {
+    let msgStr = message instanceof ArrayBuffer ? Buffer.from(message).toString() : message
+    const msg = JSON.parse(msgStr)
+    if (msg.id === '0') {
+      if (msg.error) {
+        // TODO: should let end-users decide if this should be logged or not
+        console.log(`JSON-RPC Error ${msg.error.code} (${msg.error.message}): ${msg.error.data}`)
+      } else {
+        this._subscribers.forEach(listener => listener(msg.result))
+      }
+    }
   }
 }

--- a/src/tests/address_test.ts
+++ b/src/tests/address_test.ts
@@ -12,6 +12,14 @@ test('Address', t => {
     const addr = Address.fromString(addrStr)
     t.equal(addr.chainId, chainId, 'Address.fromString() returns correct chain ID')
     t.deepEqual(addr.local, localAddr, 'Address.fromString() returns correct bytes')
+    t.ok(
+      addr.equals(new Address(chainId, LocalAddress.fromHexString(localAddrStr))),
+      'Address.equals() equality'
+    )
+    t.notOk(
+      addr.equals(new Address('other', LocalAddress.fromHexString(localAddrStr))),
+      'Address.equals() inequality'
+    )
     // TODO: make this a case sensitive comparison
     t.equal(
       addr.toString(),

--- a/src/tests/integration_test.ts
+++ b/src/tests/integration_test.ts
@@ -2,7 +2,7 @@ import test from 'tape'
 
 import { Contract } from '../contract'
 import { Address, LocalAddress } from '../address'
-import { Client } from '../client'
+import { Client, IChainEventArgs } from '../client'
 import { generatePrivateKey, publicKeyFromPrivateKey } from '../crypto-utils'
 import { NonceTxMiddleware, SignedTxMiddleware } from '../middleware'
 import { MapEntry, HelloRequest, HelloResponse } from './tests_pb'
@@ -32,6 +32,14 @@ test('Contract Calls', async t => {
     const msg = new MapEntry()
     msg.setKey(msgKey)
     msg.setValue(msgValue)
+
+    contract.once(Contract.EVENT, (event: IChainEventArgs) => {
+      t.deepEqual(event.contractAddress, contractAddr, 'IChainEventArgs.contractAddress matches')
+      t.deepEqual(event.callerAddress, callerAddr, 'IChainEventArgs.callerAddress matches')
+      t.ok(event.blockHeight, 'IChainEventArgs.blockHeight is set')
+      t.ok(event.data.length > 0, 'IChainEventArgs.data is set')
+      // TODO: verify data is correct
+    })
     await contract.callAsync<void>('SetMsg', msg)
 
     const retVal = await contract.callAsync<MapEntry>('SetMsgEcho', msg, new MapEntry())


### PR DESCRIPTION
`Client` and `Contract` are now both event emitters, so they have acquired
the [Node EventEmitter API](https://nodejs.org/api/events.html).

```typescript
// listen to events emitted by a specific smart contract
contract.on/once(Contract.EVENT, (event: IChainEventArgs) => {
  // handle event
})

// listen to events emitted by any smart contract
client.on/once(ClientEvent.Contract, (event: IChainEventArgs) => {
  // handle event
})
```

TODO:
- [x] Test IChainEventArgs.data is being decoded correctly
- [x] Update EvmContract