### PR TITLE
Update client event subscription to work with new loomchain

### DIFF
--- a/src/internal/ws-rpc-client.ts
+++ b/src/internal/ws-rpc-client.ts
@@ -3,15 +3,15 @@ import { EventEmitter } from 'events'
 
 export interface IEventData {
   caller: {
-    ChainID: string
-    Local: string
+    chain_id: string
+    local: string
   }
   address: {
-    ChainID: string
-    Local: string
+    chain_id: string
+    local: string
   }
-  blockHeight: string
-  encodedData: string
+  block_height: string
+  encoded_body: string
 }
 
 export interface IJSONRPCError {
@@ -107,7 +107,7 @@ export class WSRPCClient extends EventEmitter {
         ;((this._client as any).socket as EventEmitter).on('message', this._onEventMessage)
         if (this._client.ready) {
           this._client
-            .call('subevents', {}, this.requestTimeout)
+            .call('subevents', { topic: null }, this.requestTimeout)
             .then(() => {
               this._isSubcribed = true
               this.emit(WSRPCClientEvent.Subscribed, true)
@@ -125,7 +125,7 @@ export class WSRPCClient extends EventEmitter {
         )
         if (this._client.ready) {
           this._client
-            .call('unsubevents', {}, this.requestTimeout)
+            .call('unsubevents', { topic: null }, this.requestTimeout)
             .then(() => {
               this._isSubcribed = false
               this.emit(WSRPCClientEvent.Subscribed, false)
@@ -139,7 +139,7 @@ export class WSRPCClient extends EventEmitter {
       this.emit(WSRPCClientEvent.Connected)
       if (this.listenerCount(WSRPCClientEvent.Message) > 0) {
         this._client
-          .call('subevents', {}, this.requestTimeout)
+          .call('subevents', { topic: null }, this.requestTimeout)
           .then(() => {
             this._isSubcribed = true
             this.emit(WSRPCClientEvent.Subscribed, true)

--- a/src/internal/ws-rpc-client.ts
+++ b/src/internal/ws-rpc-client.ts
@@ -107,7 +107,7 @@ export class WSRPCClient extends EventEmitter {
         ;((this._client as any).socket as EventEmitter).on('message', this._onEventMessage)
         if (this._client.ready) {
           this._client
-            .call('subevents', { topic: null }, this.requestTimeout)
+            .call('subevents', { topics: null }, this.requestTimeout)
             .then(() => {
               this._isSubcribed = true
               this.emit(WSRPCClientEvent.Subscribed, true)
@@ -125,7 +125,7 @@ export class WSRPCClient extends EventEmitter {
         )
         if (this._client.ready) {
           this._client
-            .call('unsubevents', { topic: null }, this.requestTimeout)
+            .call('unsubevents', { topics: null }, this.requestTimeout)
             .then(() => {
               this._isSubcribed = false
               this.emit(WSRPCClientEvent.Subscribed, false)
@@ -139,7 +139,7 @@ export class WSRPCClient extends EventEmitter {
       this.emit(WSRPCClientEvent.Connected)
       if (this.listenerCount(WSRPCClientEvent.Message) > 0) {
         this._client
-          .call('subevents', { topic: null }, this.requestTimeout)
+          .call('subevents', { topics: null }, this.requestTimeout)
           .then(() => {
             this._isSubcribed = true
             this.emit(WSRPCClientEvent.Subscribed, true)

--- a/src/proto/loom.proto
+++ b/src/proto/loom.proto
@@ -79,6 +79,17 @@ message ContractMethodCall {
 	bytes args = 2;
 }
 
+message EventData {
+    repeated string topics = 1;
+    Address caller = 2;
+    Address address = 3;
+    string plugin_name = 4;
+    uint64 block_height = 5;
+    bytes encoded_body = 6;
+    bytes original_request = 7;
+}
+
+// EVM Event
 message Event {
     Address contract = 1;
     repeated bytes topics = 2;

--- a/src/proto/loom_pb.d.ts
+++ b/src/proto/loom_pb.d.ts
@@ -369,6 +369,60 @@ export namespace ContractMethodCall {
   }
 }
 
+export class EventData extends jspb.Message {
+  clearTopicsList(): void;
+  getTopicsList(): Array<string>;
+  setTopicsList(value: Array<string>): void;
+  addTopics(value: string, index?: number): string;
+
+  hasCaller(): boolean;
+  clearCaller(): void;
+  getCaller(): Address | undefined;
+  setCaller(value?: Address): void;
+
+  hasAddress(): boolean;
+  clearAddress(): void;
+  getAddress(): Address | undefined;
+  setAddress(value?: Address): void;
+
+  getPluginName(): string;
+  setPluginName(value: string): void;
+
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
+
+  getEncodedBody(): Uint8Array | string;
+  getEncodedBody_asU8(): Uint8Array;
+  getEncodedBody_asB64(): string;
+  setEncodedBody(value: Uint8Array | string): void;
+
+  getOriginalRequest(): Uint8Array | string;
+  getOriginalRequest_asU8(): Uint8Array;
+  getOriginalRequest_asB64(): string;
+  setOriginalRequest(value: Uint8Array | string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EventData.AsObject;
+  static toObject(includeInstance: boolean, msg: EventData): EventData.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EventData, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EventData;
+  static deserializeBinaryFromReader(message: EventData, reader: jspb.BinaryReader): EventData;
+}
+
+export namespace EventData {
+  export type AsObject = {
+    topicsList: Array<string>,
+    caller?: Address.AsObject,
+    address?: Address.AsObject,
+    pluginName: string,
+    blockHeight: number,
+    encodedBody: Uint8Array | string,
+    originalRequest: Uint8Array | string,
+  }
+}
+
 export class Event extends jspb.Message {
   hasContract(): boolean;
   clearContract(): void;


### PR DESCRIPTION
Topics aren't currently exposed via the client API, and the client will receive all events from the chain. EventData is now a protobuf, but it turns out the js protobuf lib doesn't have any built-in functionality
to decode a JSON-encoded protobuf.