### PR TITLE
LoomProvider managing accounts

### DIFF
--- a/src/loom-provider.ts
+++ b/src/loom-provider.ts
@@ -5,14 +5,10 @@ import {
   MessageTx,
   Transaction,
   VMType,
-  EvmTxReceipt,
   Event,
   DeployTx,
   DeployResponse,
-  DeployResponseData,
-  Address as ProtoAddress,
-  NonceTx,
-  SignedTx
+  DeployResponseData
 } from './proto/loom_pb'
 import { Address, LocalAddress } from './address'
 import {
@@ -20,11 +16,8 @@ import {
   numberToHex,
   bufferToProtobufBytes,
   getGUID,
-  publicKeyFromPrivateKey,
-  bytesToHex,
-  sign
+  publicKeyFromPrivateKey
 } from './crypto-utils'
-import { NonceTxMiddleware, SignedTxMiddleware } from './middleware'
 
 export interface IEthReceipt {
   transactionHash: string
@@ -440,7 +433,7 @@ export class LoomProvider {
     }
 
     const middleware = createDefaultTxMiddleware(this._client, privateKey)
-    return this._client.commitTxAsync<Transaction>(txTransaction, {middleware})
+    return this._client.commitTxAsync<Transaction>(txTransaction, { middleware })
   }
 
   private _simulateEmptyBlock(block: any = {}) {


### PR DESCRIPTION
* LoomProvider now is able to manage accounts private/public keys
* Constructor now requires a private key for the main account
* LoomProvider signs transactions using the new account management

Example of how LoomProvider will work
---

```Typescript
  /**
   * Constructs a new TruffleLoomProvider using LoomProvider to provide connection to Loom DAppChain.
   * @param chainId DAppChain identifier.
   * @param writeUrl Host & port to send txs, specified as "<protocol>://<host>:<port>".
   * @param readUrl Host & port of the DAppChain read/query interface, this should only be provided
   *                if it's not the same as `writeUrl`.
   * @param privateKey Account private key in Base64 string format
   */
  constructor(chainId: string, writeUrl: string, readUrl: string, privateKey: string) {
    const _privateKey = CryptoUtils.B64ToUint8Array(privateKey)
    const client = new Client(chainId, writeUrl, readUrl)

    this._engine = new LoomProvider(client, _privateKey)
    this._engine.on('error', (err: any) => {
      console.error('Error detected within Truffle process:', err)
    })
  }
```

This update makes possible to create many accounts with Truffle Loom Provider (Code used on truffle.js to instantiate a provider)

```Javascript
const { readFileSync } = require('fs')
const LoomTruffleProvider = require('loom-truffle-provider')

const chainId    = 'default'
const writeUrl   = 'ws://127.0.0.1:46657/websocket'
const readUrl    = 'ws://127.0.0.1:9999/queryws'
const privateKey = readFileSync('./priv_key', 'utf-8')

const loomTruffleProvider = new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey)
loomTruffleProvider.createExtraAccounts(10)
```

* Now `eth_accounts` returns all accounts created
* This update will break prior versions of `1.5.0 >`, although will make the Truffle experience better