### PR TITLE
Add ability to override the set of middleware used on a per tx basis

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,17 @@
+import { Client, ITxMiddlewareHandler } from './client'
+import { NonceTxMiddleware, SignedTxMiddleware } from './middleware'
+import { publicKeyFromPrivateKey } from './crypto-utils'
+
+/**
+ * Creates the default set of tx middleware required to successfully commit a tx to a Loom DAppChain.
+ * @param client The client the middleware is being created for.
+ * @param privateKey Private key that should be used to sign txs.
+ * @returns Set of middleware.
+ */
+export function createDefaultTxMiddleware(
+  client: Client,
+  privateKey: Uint8Array
+): ITxMiddlewareHandler[] {
+  const pubKey = publicKeyFromPrivateKey(privateKey)
+  return [new NonceTxMiddleware(pubKey, client), new SignedTxMiddleware(privateKey)]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { Contract } from './contract'
 export { EvmContract } from './evm-contract'
 export { Address, LocalAddress } from './address'
 export { SignedTxMiddleware, NonceTxMiddleware } from './middleware'
+export { createDefaultTxMiddleware } from './helpers'
 export { LoomProvider } from './loom-provider'
 
 import * as CryptoUtils from './crypto-utils'

--- a/src/tests/e2e/contract-tests.ts
+++ b/src/tests/e2e/contract-tests.ts
@@ -8,7 +8,8 @@ import {
   IChainEventArgs,
   NonceTxMiddleware,
   SignedTxMiddleware,
-  CryptoUtils
+  CryptoUtils,
+  createDefaultTxMiddleware
 } from '../../index'
 import { MapEntry } from '../tests_pb'
 import { createTestClient } from '../helpers'
@@ -17,7 +18,7 @@ async function getClientAndContract(): Promise<{ client: Client; contract: Contr
   const privKey = CryptoUtils.generatePrivateKey()
   const pubKey = CryptoUtils.publicKeyFromPrivateKey(privKey)
   const client = createTestClient()
-  client.txMiddleware = [new NonceTxMiddleware(pubKey, client), new SignedTxMiddleware(privKey)]
+  client.txMiddleware = createDefaultTxMiddleware(client, privKey)
 
   let contractAddr: Address | null = null
   try {

--- a/src/tests/e2e/evm-contract-tests.ts
+++ b/src/tests/e2e/evm-contract-tests.ts
@@ -7,7 +7,8 @@ import {
   Client,
   NonceTxMiddleware,
   SignedTxMiddleware,
-  CryptoUtils
+  CryptoUtils,
+  createDefaultTxMiddleware
 } from '../../index'
 import { createTestClient } from '../helpers'
 
@@ -33,7 +34,7 @@ test('EVM Contract Calls', async t => {
     const privKey = CryptoUtils.generatePrivateKey()
     const pubKey = CryptoUtils.publicKeyFromPrivateKey(privKey)
     const client = createTestClient()
-    client.txMiddleware = [new NonceTxMiddleware(pubKey, client), new SignedTxMiddleware(privKey)]
+    client.txMiddleware = createDefaultTxMiddleware(client, privKey)
 
     const contractAddr = await client.getContractAddressAsync('SimpleStore')
     if (!contractAddr) {


### PR DESCRIPTION
Right now the intended use case is just to use multiple key pairs to send txs with a single client.