### PR TITLE
Fix default return for eth_call

### DIFF
--- a/src/loom-provider.ts
+++ b/src/loom-provider.ts
@@ -305,7 +305,7 @@ export class LoomProvider {
   private async _ethCall(payload: IEthRPCPayload) {
     // Sending a static call to Loom DAppChain
     const result = await this._callStaticAsync(payload.params[0])
-    return bytesToHexAddrLC(result)
+    return result ? bytesToHexAddrLC(result) : '0x0'
   }
 
   private _ethEstimateGas() {


### PR DESCRIPTION
Solidity default state for variables not defined is `0x0`, so to avoid errors of empty `Buffer` on `LoomProvider` and be friendly to `web3js` the return instead of `undefined` is `0x0`. Also it will fix the behavior of the command `truffle migrate` when the migrations doesn't exists on `DappChain`