### PR TITLE
Set correct sig mode when signing a message via MetaMask

### DIFF
--- a/src/plasma-cash/solidity-helpers.ts
+++ b/src/plasma-cash/solidity-helpers.ts
@@ -32,15 +32,16 @@ export class Web3Signer {
     const signature = await this._web3.eth.sign(msg, this._address)
     const sig = signature.slice(2)
 
+    let mode = 1 // Geth
     const r = ethutil.toBuffer('0x' + sig.substring(0, 64)) as Buffer
     const s = ethutil.toBuffer('0x' + sig.substring(64, 128)) as Buffer
     let v = parseInt(sig.substring(128, 130), 16)
 
     if (v === 0 || v === 1) {
       v += 27
+    } else {
+      mode = 0 // indicate that msg wasn't prefixed before signing (MetaMask doesn't prefix!)
     }
-
-    const mode = ethutil.toBuffer(1) as Buffer // mode = geth
-    return Buffer.concat([mode, r, s, ethutil.toBuffer(v) as Buffer])
+    return Buffer.concat([ethutil.toBuffer(mode) as Buffer, r, s, ethutil.toBuffer(v) as Buffer])
   }
 }


### PR DESCRIPTION
Ganache and MetaMask appear to implement web3.eth.sign differently:
- Ganache sets v to 1, while MetaMask sets it to 28
- Ganache prefixes the msg before signing, MetaMask doesn't

So we do our best to guess what actually happened and set the sig mode accordingly so the Address Mapper contract knows how to recover the signer address from the sig.