### PR TITLE
Coin History Verification & Get all user slots

### DIFF
--- a/e2e_tests.sh
+++ b/e2e_tests.sh
@@ -9,7 +9,7 @@ set -euxo pipefail
 
 # Prepare env
 DEFAULT_GOPATH=$GOPATH
-BUILD_NUMBER=450
+BUILD_NUMBER=458
 GANACHE_PORT=8545
 REPO_ROOT=`pwd`
 LOOM_DIR=`pwd`/tmp/e2e

--- a/e2e_tests.sh
+++ b/e2e_tests.sh
@@ -9,7 +9,7 @@ set -euxo pipefail
 
 # Prepare env
 DEFAULT_GOPATH=$GOPATH
-BUILD_NUMBER=434
+BUILD_NUMBER=450
 GANACHE_PORT=8545
 REPO_ROOT=`pwd`
 LOOM_DIR=`pwd`/tmp/e2e

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -130,6 +130,7 @@ export class Contract extends EventEmitter {
     const query = new ContractMethodCall()
     query.setMethod(method)
     query.setArgs(args.serializeBinary())
+
     const result = await this._client.queryAsync(
       this.address,
       query.serializeBinary(),

--- a/src/plasma-cash/dappchain-client.ts
+++ b/src/plasma-cash/dappchain-client.ts
@@ -96,7 +96,7 @@ export class DAppChainPlasmaClient {
     req.setBlockHeight(marshalBigUIntPB(blockNum))
     req.setSlot(slot.toString(10) as any)
     const resp = await contract.staticCallAsync<GetPlasmaTxResponse>(
-      'GetPlasmaTxRequest',
+      'GetPlasmaTx',
       req,
       new GetPlasmaTxResponse()
     )

--- a/src/plasma-cash/dappchain-client.ts
+++ b/src/plasma-cash/dappchain-client.ts
@@ -94,7 +94,6 @@ export class DAppChainPlasmaClient {
    * @return 
    */
   async getPlasmaTxAsync(slot: BN, blockNum: BN): Promise<PlasmaCashTx> {
-    console.log(`Getting tx at ${slot} and block ${blockNum}`)
     const contract = await this._resolvePlasmaContractAsync()
     const req = new GetPlasmaTxRequest()
     req.setBlockHeight(marshalBigUIntPB(blockNum))
@@ -127,19 +126,17 @@ export class DAppChainPlasmaClient {
    * @param slot The coin id
    * @return 
    */
-  async getUserSlotsAsync(): Promise<any[]> {
+  async getUserSlotsAsync(_ethAddress: Address): Promise<BN[]> {
     const contract = await this._resolvePlasmaContractAsync()
     const req = new GetUserSlotsRequest()
-    req.setFrom(this._callerAddress.MarshalPB())
+    req.setFrom(_ethAddress.MarshalPB())
     const resp: GetUserSlotsResponse = await contract.staticCallAsync<GetUserSlotsResponse>(
       'GetUserSlotsRequest',
       req,
       new GetUserSlotsResponse()
     )
-    return resp.getSlotsList()
+    return resp.getSlotsList().map(s => new BN(s))
   }
-
-
 
   /**
    * Transfers a Plasma token from one entity to another.

--- a/src/plasma-cash/dappchain-client.ts
+++ b/src/plasma-cash/dappchain-client.ts
@@ -12,6 +12,8 @@ import {
   GetCurrentBlockResponse,
   GetPlasmaTxRequest,
   GetPlasmaTxResponse,
+  GetUserSlotsRequest,
+  GetUserSlotsResponse,
   GetBlockRequest,
   GetBlockResponse,
   DepositRequest,
@@ -102,6 +104,27 @@ export class DAppChainPlasmaClient {
     )
     return unmarshalPlasmaTxPB(resp.getPlasmatx()!)
   }
+
+  /**
+   * Retrieves a merkle proof from the DAppChain regarding a coin at a block
+   *
+   * @param blockNum Height of the block to be retrieved.
+   * @param slot The coin id
+   * @return 
+   */
+  async getUserSlotsAsync(): Promise<any[]> {
+    const contract = await this._resolvePlasmaContractAsync()
+    const req = new GetUserSlotsRequest()
+    req.setFrom(this._callerAddress.MarshalPB())
+    const resp: GetUserSlotsResponse = await contract.staticCallAsync<GetUserSlotsResponse>(
+      'GetUserSlotsRequest',
+      req,
+      new GetUserSlotsResponse()
+    )
+    console.log('GOT USER SLOTS', resp.getSlotsList())
+    return resp.getSlotsList()
+  }
+
 
 
   /**

--- a/src/plasma-cash/dappchain-client.ts
+++ b/src/plasma-cash/dappchain-client.ts
@@ -91,7 +91,7 @@ export class DAppChainPlasmaClient {
    *
    * @param blockNum Height of the block to be retrieved.
    * @param slot The coin id
-   * @return 
+   * @return
    */
   async getPlasmaTxAsync(slot: BN, blockNum: BN): Promise<PlasmaCashTx> {
     const contract = await this._resolvePlasmaContractAsync()
@@ -103,7 +103,7 @@ export class DAppChainPlasmaClient {
       req,
       new GetPlasmaTxResponse()
     )
-    const rawTx : PlasmaTx = resp.getPlasmatx()!
+    const rawTx: PlasmaTx = resp.getPlasmaTx()!
 
     // If we're getting a non-existing transaction, we just return its slot and its non-inclusion proof
     if (!rawTx.hasNewOwner()) {
@@ -112,11 +112,11 @@ export class DAppChainPlasmaClient {
         prevBlockNum: new BN(0),
         denomination: 1,
         newOwner: '0x0000000000000000000000000000000000000000',
-        proof: rawTx.getProof_asU8(),
+        proof: rawTx.getProof_asU8()
       })
     }
 
-    return unmarshalPlasmaTxPB(resp.getPlasmatx()!)
+    return unmarshalPlasmaTxPB(resp.getPlasmaTx()!)
   }
 
   /**
@@ -124,7 +124,7 @@ export class DAppChainPlasmaClient {
    *
    * @param blockNum Height of the block to be retrieved.
    * @param slot The coin id
-   * @return 
+   * @return
    */
   async getUserSlotsAsync(_ethAddress: Address): Promise<BN[]> {
     const contract = await this._resolvePlasmaContractAsync()

--- a/src/plasma-cash/dappchain-client.ts
+++ b/src/plasma-cash/dappchain-client.ts
@@ -3,13 +3,15 @@ import BN from 'bn.js'
 import { Client } from '../client'
 import { Contract } from '../contract'
 import { Address, LocalAddress } from '../address'
-import { PlasmaCashTx, marshalPlasmaTxPB } from './plasma-cash-tx'
+import { PlasmaCashTx, marshalPlasmaTxPB, unmarshalPlasmaTxPB } from './plasma-cash-tx'
 import { PlasmaCashBlock, unmarshalPlasmaBlockPB } from './plasma-cash-block'
 import { unmarshalBigUIntPB, marshalBigUIntPB } from '../big-uint'
 import { IPlasmaDeposit } from './ethereum-client'
 import {
   GetCurrentBlockRequest,
   GetCurrentBlockResponse,
+  GetPlasmaTxRequest,
+  GetPlasmaTxResponse,
   GetBlockRequest,
   GetBlockResponse,
   DepositRequest,
@@ -80,6 +82,27 @@ export class DAppChainPlasmaClient {
     )
     return unmarshalPlasmaBlockPB(resp.getBlock()!)
   }
+
+  /**
+   * Retrieves a merkle proof from the DAppChain regarding a coin at a block
+   *
+   * @param blockNum Height of the block to be retrieved.
+   * @param slot The coin id
+   * @return 
+   */
+  async getPlasmaTxAsync(slot: BN, blockNum: BN): Promise<PlasmaCashTx> {
+    const contract = await this._resolvePlasmaContractAsync()
+    const req = new GetPlasmaTxRequest()
+    req.setBlockHeight(marshalBigUIntPB(blockNum))
+    req.setSlot(slot.toString(10) as any)
+    const resp = await contract.staticCallAsync<GetPlasmaTxResponse>(
+      'GetPlasmaTxRequest',
+      req,
+      new GetPlasmaTxResponse()
+    )
+    return unmarshalPlasmaTxPB(resp.getPlasmatx()!)
+  }
+
 
   /**
    * Transfers a Plasma token from one entity to another.

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -189,7 +189,7 @@ export class Entity {
     return this.plasmaCashContract.events
       .StartedExit({
         filter: { slot: slot },
-        fromBlock: 0
+        fromBlock: fromBlock
       })
       .on('data', (event: any, err: any) => {
         this.challengeExitAsync(slot, event.returnValues.owner)

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -102,7 +102,7 @@ export class Entity {
     return this._ethPlasmaClient.getBlockRootAsync({ blockNumber, from: this.ethAddress })
   }
 
-  async getUserSlotsAsync(): Promise<IPlasmaCoin[]> {
+  async getUserCoinsAsync(): Promise<IPlasmaCoin[]> {
     const addr = new Address('eth', LocalAddress.fromHexString(this.ethAddress))
     const slots = await this._dAppPlasmaClient.getUserSlotsAsync(addr)
 

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -101,6 +101,11 @@ export class Entity {
     return this._ethPlasmaClient.getBlockRootAsync({ blockNumber, from: this.ethAddress })
   }
 
+  getUserSlotsAsync(): Promise<any> {
+    return this._dAppPlasmaClient.getUserSlotsAsync()
+  }
+
+
   checkMembershipAsync(leaf: string, root: string, slot: BN, proof: string): Promise<boolean> {
     return this._ethPlasmaClient.checkMembershipAsync({
       leaf,

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -304,16 +304,17 @@ export class Entity {
       const blockNumber = new BN(p)
       const tx = proofs.transactions[p] // get the block number from the proof of inclusion and get the tx from that
       const root = await this.getBlockRootAsync(blockNumber)
-      const included = this.checkInclusionAsync(tx, root, slot, proofs.inclusion[p])
+      const included = await this.checkInclusionAsync(tx, root, slot, proofs.inclusion[p])
       if (!included) {
         return false
       }
     }
+
     // Check exclusion proofs
     for (let p in proofs.exclusion) {
       const blockNumber = new BN(p)
       const root = await this.getBlockRootAsync(blockNumber)
-      const excluded = this.checkExclusionAsync(root, slot, proofs.exclusion[p])
+      const excluded = await this.checkExclusionAsync(root, slot, proofs.exclusion[p])
       if (!excluded) {
         return false
       }
@@ -321,10 +322,11 @@ export class Entity {
     return true
   }
 
-  checkExclusionAsync(root: string, slot: BN, proof: string): Promise<boolean> {
+  async checkExclusionAsync(root: string, slot: BN, proof: string): Promise<boolean> {
     // keccak(uint256(0))
     const emptyHash = '0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563'
-    return this.checkMembershipAsync(emptyHash, root, slot, proof)
+    const ret = await this.checkMembershipAsync(emptyHash, root, slot, proof)
+    return ret
   }
 
   async checkInclusionAsync(

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -7,6 +7,7 @@ import {
   IPlasmaDeposit,
   IPlasmaExitData
 } from './ethereum-client'
+import { Address, LocalAddress } from '../address'
 import { DAppChainPlasmaClient } from './dappchain-client'
 import { PlasmaCashTx } from './plasma-cash-tx'
 import { Web3Signer } from '../solidity-helpers'
@@ -101,8 +102,12 @@ export class Entity {
     return this._ethPlasmaClient.getBlockRootAsync({ blockNumber, from: this.ethAddress })
   }
 
-  getUserSlotsAsync(): Promise<any> {
-    return this._dAppPlasmaClient.getUserSlotsAsync()
+  async getUserSlotsAsync(): Promise<IPlasmaCoin[]> {
+    const addr = new Address('eth', LocalAddress.fromHexString(this.ethAddress))
+    const slots = await this._dAppPlasmaClient.getUserSlotsAsync(addr)
+
+    const coins = slots.map(s => this.getPlasmaCoinAsync(s))
+    return (await Promise.all(coins))
   }
 
 

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -83,7 +83,7 @@ export class Entity {
     await this._dAppPlasmaClient.sendTxAsync(tx)
   }
 
-  getPlasmaTx(slot: BN, blockNumber: BN): Promise<PlasmaCashTx> {
+  getPlasmaTxAsync(slot: BN, blockNumber: BN): Promise<PlasmaCashTx> {
     return this._dAppPlasmaClient.getPlasmaTxAsync(slot, blockNumber)
   }
 
@@ -155,11 +155,11 @@ export class Entity {
       })
     }
 
-    const exitTx = await this.getPlasmaTx(slot, exitBlockNum)
+    const exitTx = await this.getPlasmaTxAsync(slot, exitBlockNum)
     if (!exitTx) {
       throw new Error(`Invalid exit block: missing tx for slot ${slot.toString(10)}.`)
     }
-    const prevTx = await this.getPlasmaTx(slot, prevBlockNum)
+    const prevTx = await this.getPlasmaTxAsync(slot, prevBlockNum)
     if (!prevTx) {
       throw new Error(`Invalid prev block: missing tx for slot ${slot.toString(10)}.`)
     }
@@ -246,7 +246,7 @@ export class Entity {
       } else if (blk.lt(exit.prevBlock)) {
         console.log('Challenge Invalid History!')
         // This should happen on the DAppChain side and return the specified tx, instead of the whole block
-        const tx = await this.getPlasmaTx(slot, blk)
+        const tx = await this.getPlasmaTxAsync(slot, blk)
         await this.challengeBeforeAsync({
           slot: slot,
           prevBlockNum: tx.prevBlockNum,
@@ -289,7 +289,7 @@ export class Entity {
       const blockNumber = blockNumbers[i]
       const root = await this.getBlockRootAsync(blockNumber)
 
-      const tx = await this.getPlasmaTx(slot, blockNumber)
+      const tx = await this.getPlasmaTxAsync(slot, blockNumber)
 
       txs[blockNumber.toString()] = tx
       const included = await this.checkInclusionAsync(tx, root, slot, tx.proof)
@@ -362,7 +362,6 @@ export class Entity {
     return deposits
   }
 
-
   async getBlockNumbersAsync(startBlock: any): Promise<BN[]> {
     const endBlock: BN = await this.getCurrentBlockAsync()
     const nextDepositBlock: BN = new BN(
@@ -397,7 +396,7 @@ export class Entity {
 
   async challengeAfterAsync(params: { slot: BN; challengingBlockNum: BN }): Promise<object> {
     const { slot, challengingBlockNum } = params
-    const challengingTx = await this.getPlasmaTx(slot, challengingBlockNum)
+    const challengingTx = await this.getPlasmaTxAsync(slot, challengingBlockNum)
     if (!challengingTx) {
       throw new Error(`Invalid challenging block: missing tx for slot ${slot.toString(10)}.`)
     }
@@ -412,7 +411,7 @@ export class Entity {
 
   async challengeBetweenAsync(params: { slot: BN; challengingBlockNum: BN }): Promise<object> {
     const { slot, challengingBlockNum } = params
-    const challengingTx = await this.getPlasmaTx(slot, challengingBlockNum)
+    const challengingTx = await this.getPlasmaTxAsync(slot, challengingBlockNum)
     if (!challengingTx) {
       throw new Error(`Invalid challenging block: missing tx for slot ${slot.toString(10)}.`)
     }
@@ -452,11 +451,11 @@ export class Entity {
     }
 
     // Otherwise, they should get the raw tx info from the blocks, and the merkle proofs.
-    const challengingTx = await this.getPlasmaTx(slot, challengingBlockNum)
+    const challengingTx = await this.getPlasmaTxAsync(slot, challengingBlockNum)
     if (!challengingTx) {
       throw new Error(`Invalid exit block: missing tx for slot ${slot.toString(10)}.`)
     }
-    const prevTx = await this.getPlasmaTx(slot, challengingBlockNum)
+    const prevTx = await this.getPlasmaTxAsync(slot, challengingBlockNum)
     if (!prevTx) {
       throw new Error(`Invalid prev block: missing tx for slot ${slot.toString(10)}.`)
     }
@@ -477,7 +476,7 @@ export class Entity {
     respondingBlockNum: BN
   }): Promise<object> {
     const { slot, challengingTxHash, respondingBlockNum } = params
-    const respondingTx = await this.getPlasmaTx(slot, respondingBlockNum)
+    const respondingTx = await this.getPlasmaTxAsync(slot, respondingBlockNum)
     if (!respondingTx) {
       throw new Error(`Invalid responding block: missing tx for slot ${slot.toString(10)}.`)
     }

--- a/src/plasma-cash/ethereum-client.ts
+++ b/src/plasma-cash/ethereum-client.ts
@@ -18,6 +18,7 @@ export enum PlasmaCoinState {
 }
 
 export interface IPlasmaCoin {
+  slot: BN
   /** Identifier of an ERC721 token. */
   uid: BN
   /** Plasma block number at which this coin was deposited. */
@@ -178,6 +179,7 @@ export class EthereumPlasmaClient {
     const { slot, from } = params
     const coin = await this._plasmaContract.methods.getPlasmaCoin(slot).call({ from })
     return {
+      slot: slot,
       uid: new BN(coin[0]),
       depositBlockNum: new BN(coin[1]),
       denomination: new BN(coin[2]),

--- a/src/proto/plasma_cash.proto
+++ b/src/proto/plasma_cash.proto
@@ -2,13 +2,6 @@ syntax = "proto3";
 
 import "proto/loom.proto";
 
-message PlasmaCashAccount {
-    Address owner = 1;
-    // Address of ERC721 contract the tokens in the Plasma coins originated
-    // from
-    repeated uint64 slots = 2;
-}
-
 message PlasmaBlock {
     BigUInt uid = 1; // Plasma block height/number
     repeated PlasmaTx transactions = 2; // Transactions included in the block
@@ -74,7 +67,7 @@ message GetUserSlotsRequest {
 }
 
 message GetUserSlotsResponse {
-    repeated uint64 slots = 1;
+    repeated uint64 slots = 1 [jstype = JS_STRING];
 }
 
 message DepositRequest {

--- a/src/proto/plasma_cash.proto
+++ b/src/proto/plasma_cash.proto
@@ -11,7 +11,7 @@ message PlasmaBlock {
     bytes proof = 6; // TODO: remove?
 }
 
-message PlasmaTx { 
+message PlasmaTx {
     uint64 slot = 1 [jstype = JS_STRING]; // The slot of the UTXO - Currently uint64, subject to change.
     BigUInt previous_block = 2; // BigUInt //Each time a transaction is created, it MUST refer to a previous block which also included that transaction. A transaction is considered a “deposit transaction”, if it’s the first UTXO after a user deposits their coin in the Plasma Chain. This transaction mints coins from nowhere in the Plasma Chain and as a result its previous block is 0.
     BigUInt denomination = 3; // BigUInt // How many coins are included in that UTXO. Currently this is always 1 since we’re using ERC721 tokens which are unique, however in future iterations this can be any number.
@@ -59,7 +59,7 @@ message GetPlasmaTxRequest {
 }
 
 message GetPlasmaTxResponse {
-    PlasmaTx plasmatx= 1;
+    PlasmaTx plasma_tx= 1;
 }
 
 message GetUserSlotsRequest {

--- a/src/proto/plasma_cash.proto
+++ b/src/proto/plasma_cash.proto
@@ -2,6 +2,15 @@ syntax = "proto3";
 
 import "proto/loom.proto";
 
+message PlasmaCashAccount {
+    Address owner = 1;
+    // Address of ERC721 contract the tokens in the Plasma coins originated
+    // from
+    Address contract = 2;
+    // Plasma coins in this account, identified by their slot number.
+    repeated uint64 slots = 3;
+}
+
 message PlasmaBlock {
     BigUInt uid = 1; // Plasma block height/number
     repeated PlasmaTx transactions = 2; // Transactions included in the block
@@ -51,6 +60,22 @@ message PlasmaTxRequest {
 }
 
 message PlasmaTxResponse {
+}
+
+message GetPlasmaTxRequest {
+    uint64 slot = 1; // The slot of the UTXO - Currently uint64, subject to change.
+    BigUInt block_height = 2;
+}
+
+message GetPlasmaTxResponse {
+    PlasmaTx plasmatx= 1;
+}
+
+message GetUserSlotsRequest {
+    PlasmaCashAccount account = 1;
+}
+
+message GetUserSlotsResponse {
 }
 
 message DepositRequest {

--- a/src/proto/plasma_cash.proto
+++ b/src/proto/plasma_cash.proto
@@ -6,9 +6,7 @@ message PlasmaCashAccount {
     Address owner = 1;
     // Address of ERC721 contract the tokens in the Plasma coins originated
     // from
-    Address contract = 2;
-    // Plasma coins in this account, identified by their slot number.
-    repeated uint64 slots = 3;
+    repeated uint64 slots = 2;
 }
 
 message PlasmaBlock {
@@ -72,10 +70,11 @@ message GetPlasmaTxResponse {
 }
 
 message GetUserSlotsRequest {
-    PlasmaCashAccount account = 1;
+    Address from = 1;
 }
 
 message GetUserSlotsResponse {
+    repeated uint64 slots = 1;
 }
 
 message DepositRequest {

--- a/src/proto/plasma_cash.proto
+++ b/src/proto/plasma_cash.proto
@@ -61,7 +61,7 @@ message PlasmaTxResponse {
 }
 
 message GetPlasmaTxRequest {
-    uint64 slot = 1; // The slot of the UTXO - Currently uint64, subject to change.
+    uint64 slot = 1 [jstype = JS_STRING]; // The slot of the UTXO - Currently uint64, subject to change.
     BigUInt block_height = 2;
 }
 

--- a/src/proto/plasma_cash_pb.d.ts
+++ b/src/proto/plasma_cash_pb.d.ts
@@ -309,10 +309,10 @@ export namespace GetPlasmaTxRequest {
 }
 
 export class GetPlasmaTxResponse extends jspb.Message {
-  hasPlasmatx(): boolean;
-  clearPlasmatx(): void;
-  getPlasmatx(): PlasmaTx | undefined;
-  setPlasmatx(value?: PlasmaTx): void;
+  hasPlasmaTx(): boolean;
+  clearPlasmaTx(): void;
+  getPlasmaTx(): PlasmaTx | undefined;
+  setPlasmaTx(value?: PlasmaTx): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetPlasmaTxResponse.AsObject;
@@ -326,7 +326,7 @@ export class GetPlasmaTxResponse extends jspb.Message {
 
 export namespace GetPlasmaTxResponse {
   export type AsObject = {
-    plasmatx?: PlasmaTx.AsObject,
+    plasmaTx?: PlasmaTx.AsObject,
   }
 }
 

--- a/src/proto/plasma_cash_pb.d.ts
+++ b/src/proto/plasma_cash_pb.d.ts
@@ -4,6 +4,40 @@
 import * as jspb from "google-protobuf";
 import * as proto_loom_pb from "../proto/loom_pb";
 
+export class PlasmaCashAccount extends jspb.Message {
+  hasOwner(): boolean;
+  clearOwner(): void;
+  getOwner(): proto_loom_pb.Address | undefined;
+  setOwner(value?: proto_loom_pb.Address): void;
+
+  hasContract(): boolean;
+  clearContract(): void;
+  getContract(): proto_loom_pb.Address | undefined;
+  setContract(value?: proto_loom_pb.Address): void;
+
+  clearSlotsList(): void;
+  getSlotsList(): Array<number>;
+  setSlotsList(value: Array<number>): void;
+  addSlots(value: number, index?: number): number;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PlasmaCashAccount.AsObject;
+  static toObject(includeInstance: boolean, msg: PlasmaCashAccount): PlasmaCashAccount.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PlasmaCashAccount, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PlasmaCashAccount;
+  static deserializeBinaryFromReader(message: PlasmaCashAccount, reader: jspb.BinaryReader): PlasmaCashAccount;
+}
+
+export namespace PlasmaCashAccount {
+  export type AsObject = {
+    owner?: proto_loom_pb.Address.AsObject,
+    contract?: proto_loom_pb.Address.AsObject,
+    slotsList: Array<number>,
+  }
+}
+
 export class PlasmaBlock extends jspb.Message {
   hasUid(): boolean;
   clearUid(): void;
@@ -278,6 +312,92 @@ export class PlasmaTxResponse extends jspb.Message {
 }
 
 export namespace PlasmaTxResponse {
+  export type AsObject = {
+  }
+}
+
+export class GetPlasmaTxRequest extends jspb.Message {
+  getSlot(): number;
+  setSlot(value: number): void;
+
+  hasBlockHeight(): boolean;
+  clearBlockHeight(): void;
+  getBlockHeight(): proto_loom_pb.BigUInt | undefined;
+  setBlockHeight(value?: proto_loom_pb.BigUInt): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetPlasmaTxRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetPlasmaTxRequest): GetPlasmaTxRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetPlasmaTxRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetPlasmaTxRequest;
+  static deserializeBinaryFromReader(message: GetPlasmaTxRequest, reader: jspb.BinaryReader): GetPlasmaTxRequest;
+}
+
+export namespace GetPlasmaTxRequest {
+  export type AsObject = {
+    slot: number,
+    blockHeight?: proto_loom_pb.BigUInt.AsObject,
+  }
+}
+
+export class GetPlasmaTxResponse extends jspb.Message {
+  hasPlasmatx(): boolean;
+  clearPlasmatx(): void;
+  getPlasmatx(): PlasmaTx | undefined;
+  setPlasmatx(value?: PlasmaTx): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetPlasmaTxResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetPlasmaTxResponse): GetPlasmaTxResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetPlasmaTxResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetPlasmaTxResponse;
+  static deserializeBinaryFromReader(message: GetPlasmaTxResponse, reader: jspb.BinaryReader): GetPlasmaTxResponse;
+}
+
+export namespace GetPlasmaTxResponse {
+  export type AsObject = {
+    plasmatx?: PlasmaTx.AsObject,
+  }
+}
+
+export class GetUserSlotsRequest extends jspb.Message {
+  hasAccount(): boolean;
+  clearAccount(): void;
+  getAccount(): PlasmaCashAccount | undefined;
+  setAccount(value?: PlasmaCashAccount): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetUserSlotsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetUserSlotsRequest): GetUserSlotsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetUserSlotsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetUserSlotsRequest;
+  static deserializeBinaryFromReader(message: GetUserSlotsRequest, reader: jspb.BinaryReader): GetUserSlotsRequest;
+}
+
+export namespace GetUserSlotsRequest {
+  export type AsObject = {
+    account?: PlasmaCashAccount.AsObject,
+  }
+}
+
+export class GetUserSlotsResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetUserSlotsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetUserSlotsResponse): GetUserSlotsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetUserSlotsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetUserSlotsResponse;
+  static deserializeBinaryFromReader(message: GetUserSlotsResponse, reader: jspb.BinaryReader): GetUserSlotsResponse;
+}
+
+export namespace GetUserSlotsResponse {
   export type AsObject = {
   }
 }

--- a/src/proto/plasma_cash_pb.d.ts
+++ b/src/proto/plasma_cash_pb.d.ts
@@ -10,11 +10,6 @@ export class PlasmaCashAccount extends jspb.Message {
   getOwner(): proto_loom_pb.Address | undefined;
   setOwner(value?: proto_loom_pb.Address): void;
 
-  hasContract(): boolean;
-  clearContract(): void;
-  getContract(): proto_loom_pb.Address | undefined;
-  setContract(value?: proto_loom_pb.Address): void;
-
   clearSlotsList(): void;
   getSlotsList(): Array<number>;
   setSlotsList(value: Array<number>): void;
@@ -33,7 +28,6 @@ export class PlasmaCashAccount extends jspb.Message {
 export namespace PlasmaCashAccount {
   export type AsObject = {
     owner?: proto_loom_pb.Address.AsObject,
-    contract?: proto_loom_pb.Address.AsObject,
     slotsList: Array<number>,
   }
 }
@@ -365,10 +359,10 @@ export namespace GetPlasmaTxResponse {
 }
 
 export class GetUserSlotsRequest extends jspb.Message {
-  hasAccount(): boolean;
-  clearAccount(): void;
-  getAccount(): PlasmaCashAccount | undefined;
-  setAccount(value?: PlasmaCashAccount): void;
+  hasFrom(): boolean;
+  clearFrom(): void;
+  getFrom(): proto_loom_pb.Address | undefined;
+  setFrom(value?: proto_loom_pb.Address): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetUserSlotsRequest.AsObject;
@@ -382,11 +376,16 @@ export class GetUserSlotsRequest extends jspb.Message {
 
 export namespace GetUserSlotsRequest {
   export type AsObject = {
-    account?: PlasmaCashAccount.AsObject,
+    from?: proto_loom_pb.Address.AsObject,
   }
 }
 
 export class GetUserSlotsResponse extends jspb.Message {
+  clearSlotsList(): void;
+  getSlotsList(): Array<number>;
+  setSlotsList(value: Array<number>): void;
+  addSlots(value: number, index?: number): number;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetUserSlotsResponse.AsObject;
   static toObject(includeInstance: boolean, msg: GetUserSlotsResponse): GetUserSlotsResponse.AsObject;
@@ -399,6 +398,7 @@ export class GetUserSlotsResponse extends jspb.Message {
 
 export namespace GetUserSlotsResponse {
   export type AsObject = {
+    slotsList: Array<number>,
   }
 }
 

--- a/src/proto/plasma_cash_pb.d.ts
+++ b/src/proto/plasma_cash_pb.d.ts
@@ -4,34 +4,6 @@
 import * as jspb from "google-protobuf";
 import * as proto_loom_pb from "../proto/loom_pb";
 
-export class PlasmaCashAccount extends jspb.Message {
-  hasOwner(): boolean;
-  clearOwner(): void;
-  getOwner(): proto_loom_pb.Address | undefined;
-  setOwner(value?: proto_loom_pb.Address): void;
-
-  clearSlotsList(): void;
-  getSlotsList(): Array<number>;
-  setSlotsList(value: Array<number>): void;
-  addSlots(value: number, index?: number): number;
-
-  serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): PlasmaCashAccount.AsObject;
-  static toObject(includeInstance: boolean, msg: PlasmaCashAccount): PlasmaCashAccount.AsObject;
-  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: PlasmaCashAccount, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): PlasmaCashAccount;
-  static deserializeBinaryFromReader(message: PlasmaCashAccount, reader: jspb.BinaryReader): PlasmaCashAccount;
-}
-
-export namespace PlasmaCashAccount {
-  export type AsObject = {
-    owner?: proto_loom_pb.Address.AsObject,
-    slotsList: Array<number>,
-  }
-}
-
 export class PlasmaBlock extends jspb.Message {
   hasUid(): boolean;
   clearUid(): void;

--- a/src/tests/e2e/client-evm-tests.ts
+++ b/src/tests/e2e/client-evm-tests.ts
@@ -23,14 +23,16 @@ test('Client EVM test (newBlockEvmFilterAsync)', async t => {
     // calls newblockevmfilter
     const filterId = await client.newBlockEvmFilterAsync()
 
+    await waitForMillisecondsAsync(1000)
+
     if (!filterId) {
       t.fail('Filter Id cannot be null')
     }
 
-    await waitForMillisecondsAsync(1000)
-
     // calls getevmfilterchanges
     const hash = await client.getEvmFilterChangesAsync(filterId as string)
+
+    await waitForMillisecondsAsync(1000)
 
     if (!hash) {
       t.fail('Block cannot be null')
@@ -42,6 +44,8 @@ test('Client EVM test (newBlockEvmFilterAsync)', async t => {
     const block: EthBlockInfo = (await client.getEvmBlockByHashAsync(
       bytesToHexAddr(blockList[0] as Uint8Array)
     )) as EthBlockInfo
+
+    await waitForMillisecondsAsync(1000)
 
     if (!block) {
       t.fail('Block cannot be null')

--- a/src/tests/e2e/loom-provider-eth-filters-2.ts
+++ b/src/tests/e2e/loom-provider-eth-filters-2.ts
@@ -31,10 +31,9 @@ test('LoomProvider + Filters 2', async t => {
       params: [ethNewBlockFilter.result]
     })
 
-    t.assert(
-      ethGetFilterChanges.result.length > 0,
-      'Should return the hash for a new block created'
-    )
+    await waitForMillisecondsAsync(1000)
+
+    t.assert(ethGetFilterChanges.result.length > 0, '')
 
     console.log('Hash for the latest block is:', ethGetFilterChanges.result)
 


### PR DESCRIPTION
Adds two methods:
- `getPlasmaTx`: This calls the `GetPlasmaTx` method of Loomchain and returns the transaction at a slot at a specific block. This is required for the exclusion proofs during history verification of a coin.
- `getUserCoins`: This calls the `GetUsersSlots` method of Loomchain to retrieve all the slots (coinIds) that the user owns. Subsequently it calls `getPlasmaCoinAsync` on each of them in order to retrieve relevant metadata. 

With these functions the Plasma Cash API is complete and a full client can be built.