### PR TITLE
Lazy loading lowdb/adapters

### DIFF
--- a/src/plasma-cash/db.ts
+++ b/src/plasma-cash/db.ts
@@ -1,6 +1,4 @@
 import low from 'lowdb'
-import FileSync from 'lowdb/adapters/FileSync'
-import LocalStorage from 'lowdb/adapters/LocalStorage'
 import { PlasmaCashTx } from './plasma-cash-tx'
 import BN from 'bn.js'
 
@@ -10,8 +8,10 @@ class PlasmaDB {
     // If we're on node.js
     let adapter
     if (typeof localStorage === 'undefined' || localStorage === null) {
+      const FileSync = require('lowdb/adapters/FileSync')
       adapter = new FileSync(`db/db_${privateKey}.json`)
     } else {
+      const LocalStorage = require('lowdb/adapters/LocalStorage')
       adapter = new LocalStorage('db')
     }
     this.db = low(adapter)


### PR DESCRIPTION
* This fix help to avoid the error
https://github.com/typicode/lowdb/issues/211 which happens when webpack
loader import the module graceful-fs calling a fs module from Node.js
which isn't available on webpack, by lazy loading the loom-js only calls
when necessary (only when used on Node.js)