### PR TITLE
Export OfflineWeb3Signer

### DIFF
--- a/src/contracts/address-mapper.ts
+++ b/src/contracts/address-mapper.ts
@@ -6,7 +6,7 @@ import {
   AddressMapperGetMappingRequest,
   AddressMapperGetMappingResponse
 } from '../proto/address_mapper_pb'
-import { Web3Signer, soliditySha3 } from '../solidity-helpers'
+import { IEthereumSigner, soliditySha3 } from '../solidity-helpers'
 
 export interface IAddressMapping {
   from: Address
@@ -30,7 +30,7 @@ export class AddressMapper extends Contract {
   async addIdentityMappingAsync(
     from: Address,
     to: Address,
-    web3Signer: Web3Signer
+    web3Signer: IEthereumSigner
   ): Promise<Uint8Array | void> {
     const mappingIdentityRequest = new AddressMapperAddIdentityMappingRequest()
     mappingIdentityRequest.setFrom(from.MarshalPB())

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export {
   marshalChallengeEvent
 } from './plasma-cash/ethereum-client'
 export { PlasmaCashTx } from './plasma-cash/plasma-cash-tx'
-export { Web3Signer, soliditySha3 } from './solidity-helpers'
+export { IEthereumSigner, Web3Signer, OfflineWeb3Signer, soliditySha3 } from './solidity-helpers'
 export { EthErc721Contract } from './plasma-cash/eth-erc721-contract'
 export { Entity, IEntityParams } from './plasma-cash/entity'
 export { SparseMerkleTree, ISparseMerkleTreeLevel } from './plasma-cash/sparse-merkle-tree'

--- a/src/solidity-helpers.ts
+++ b/src/solidity-helpers.ts
@@ -9,9 +9,17 @@ export function soliditySha3(...values: any[]): string {
 }
 
 /**
- * Signs message using a Web3 account.
+ * Signs messages using an Ethereum private key.
  */
-export class Web3Signer {
+export interface IEthereumSigner {
+  signAsync(msg: string): Promise<Uint8Array>
+}
+
+/**
+ * Signs message using a Web3 account.
+ * This signer should be used for interactive signing in the browser with MetaMask.
+ */
+export class Web3Signer implements IEthereumSigner {
   private _web3: Web3
   private _address: string
 
@@ -49,8 +57,9 @@ export class Web3Signer {
 
 /**
  * Signs message using a Web3 account.
+ * This signer should be used for signing in NodeJS.
  */
-export class OfflineWeb3Signer {
+export class OfflineWeb3Signer implements IEthereumSigner {
   private _web3: Web3
   private _account: Account
 


### PR DESCRIPTION
AddressMapper.addIdentityMappingAsync() now accepts IEthereumSigner instead of Web3Signer, the interface is implemented by both Web3Signer and OfflineWeb3Signer. The former should be used in the browser, and latter in NodeJS.