### PR TITLE
Bug fixes in block search for exits/transfers

### DIFF
--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -110,10 +110,6 @@ export class Entity {
     const blocks = await this.getBlockNumbersAsync(coin.depositBlockNum)
     const proofs = await this.getCoinHistoryAsync(coin.slot, blocks) // this will add the coin to state
     const valid = await this.verifyCoinHistoryAsync(coin.slot, proofs)
-    if (!valid) {
-      // this.database.removeCoin(coin.slot)
-      console.log(`Invalid history for ${coin.slot}...rejecting`)
-    }
     return valid
   }
 
@@ -387,7 +383,6 @@ export class Entity {
       const blockNumber = new BN(p)
       const root = await this.getBlockRootAsync(blockNumber)
       const excluded = await this.checkExclusionAsync(root, slot, proofs.exclusion[p])
-      console.log("Check:", slot, blockNumber, excluded)
       if (!excluded) {
         return false
       }


### PR DESCRIPTION
- Add `receiveCoin` function. This should be called by a user when refreshing their coin state. On the user side, after receiving the coin and validating the output is true, they should start watching.
- FIx certain 'optimizations' which didn't save user state correctly.