### PR TITLE
Add AddressMapper Auth

### DIFF
--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -4,6 +4,6 @@ set -euxo pipefail
 
 eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 
-export BUILD_NUMBER=560
+export BUILD_NUMBER=573
 bash e2e_tests.sh
 bash e2e_plasma_cash_test.sh

--- a/e2e_plasma_cash_test.sh
+++ b/e2e_plasma_cash_test.sh
@@ -150,13 +150,15 @@ fi
 
 trap cleanup EXIT
 
+# Cleanup all database files
+cd $REPO_ROOT
+rm *_db
+
 # Reset the DAppChain again for the JS tests
 init_honest_dappchain
 start_chains
 
 cd $LOOM_DIR
-mkdir -p db
-rm -rf db/*.json # remove all previously stored db related files
 
 yarn e2e:plasma-cash:honest
 
@@ -168,8 +170,11 @@ sleep 10
 init_hostile_dappchain
 start_chains
 
+# Cleanup all database files
+cd $REPO_ROOT
+rm *_db
+
 cd $LOOM_DIR
-rm -rf db/*.json # remove all previously stored db related files
 yarn e2e:plasma-cash:hostile
 
 if [[ $LOOM_DIR ]]; then 

--- a/e2e_plasma_cash_test.sh
+++ b/e2e_plasma_cash_test.sh
@@ -152,7 +152,7 @@ trap cleanup EXIT
 
 # Cleanup all database files
 cd $REPO_ROOT
-rm *_db
+rm -f *_db
 
 # Reset the DAppChain again for the JS tests
 init_honest_dappchain
@@ -172,7 +172,7 @@ start_chains
 
 # Cleanup all database files
 cd $REPO_ROOT
-rm *_db
+rm -f *_db
 
 cd $LOOM_DIR
 yarn e2e:plasma-cash:hostile

--- a/e2e_plasma_cash_test.sh
+++ b/e2e_plasma_cash_test.sh
@@ -179,4 +179,4 @@ yarn e2e:plasma-cash:hostile
 
 if [[ $LOOM_DIR ]]; then 
   rm -rf $LOOM_DIR
-  fi
+fi

--- a/e2e_support/plasma-cash/honest.genesis.json
+++ b/e2e_support/plasma-cash/honest.genesis.json
@@ -27,6 +27,12 @@
             }
         },
         {
+			"vm": "plugin",
+			"format": "plugin",
+			"name": "addressmapper",
+			"location": "addressmapper:0.1.0"
+        },
+        {
             "vm": "plugin",
             "format": "plugin",
             "name": "plasmacash",

--- a/e2e_support/plasma-cash/honest.genesis.json
+++ b/e2e_support/plasma-cash/honest.genesis.json
@@ -27,10 +27,10 @@
             }
         },
         {
-			"vm": "plugin",
-			"format": "plugin",
-			"name": "addressmapper",
-			"location": "addressmapper:0.1.0"
+            "vm": "plugin",
+            "format": "plugin",
+            "name": "addressmapper",
+            "location": "addressmapper:0.1.0"
         },
         {
             "vm": "plugin",
@@ -38,12 +38,11 @@
             "name": "plasmacash",
             "location": "plasmacash:1.0.0",
             "init": {
-               "oracle": {
-                   "chain_id": "default",
-                   "local": "XL7GoIlPLetSJSwht53TanLM2lc="
-               }
-               
-             }
+                "oracle": {
+                    "chain_id": "default",
+                    "local": "XL7GoIlPLetSJSwht53TanLM2lc="
+                }
+            }
         }
     ]
 }

--- a/e2e_support/plasma-cash/hostile.genesis.json
+++ b/e2e_support/plasma-cash/hostile.genesis.json
@@ -27,6 +27,12 @@
             }
         },
         {
+			"vm": "plugin",
+			"format": "plugin",
+			"name": "addressmapper",
+			"location": "addressmapper:0.1.0"
+        },
+        {
             "vm": "plugin",
             "format": "plugin",
             "name": "plasmacash",

--- a/e2e_support/plasma-cash/hostile.genesis.json
+++ b/e2e_support/plasma-cash/hostile.genesis.json
@@ -27,10 +27,10 @@
             }
         },
         {
-			"vm": "plugin",
-			"format": "plugin",
-			"name": "addressmapper",
-			"location": "addressmapper:0.1.0"
+            "vm": "plugin",
+            "format": "plugin",
+            "name": "addressmapper",
+            "location": "addressmapper:0.1.0"
         },
         {
             "vm": "plugin",
@@ -39,8 +39,8 @@
             "location": "plasmacash:1.0.0",
             "init": {
                 "oracle": {
-                     "chain_id": "default",
-                     "local": "XL7GoIlPLetSJSwht53TanLM2lc="
+                    "chain_id": "default",
+                    "local": "XL7GoIlPLetSJSwht53TanLM2lc="
                 }
             }
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,13 @@ export {
   marshalChallengeEvent
 } from './plasma-cash/ethereum-client'
 export { PlasmaCashTx } from './plasma-cash/plasma-cash-tx'
-export { IEthereumSigner, OfflineWeb3Signer, Web3Signer, EthersSigner, soliditySha3 } from './solidity-helpers'
+export {
+  IEthereumSigner,
+  OfflineWeb3Signer,
+  Web3Signer,
+  EthersSigner,
+  soliditySha3
+} from './solidity-helpers'
 export { Entity, IEntityParams } from './plasma-cash/entity'
 export { User as PlasmaUser } from './plasma-cash/user'
 export { SparseMerkleTree, ISparseMerkleTreeLevel } from './plasma-cash/sparse-merkle-tree'

--- a/src/plasma-cash/user.ts
+++ b/src/plasma-cash/user.ts
@@ -56,7 +56,7 @@ export class User extends Entity {
     const signer = provider.getSigner()
     return this.createUser(
       signer,
-      '0x',
+      null,
       plasmaAddress,
       dappchainEndpoint,
       eventsEndpoint,
@@ -93,7 +93,7 @@ export class User extends Entity {
 
   static async createUser(
     wallet: ethers.Signer,
-    dappchainPrivateKey: string,
+    dappchainPrivateKey: string | null,
     plasmaAddress: string,
     dappchainEndpoint: string,
     eventsEndpoint: string,
@@ -107,7 +107,7 @@ export class User extends Entity {
     const reader = createJSONRPCClient({ protocols: [{ url: dappchainEndpoint + '/query' }] })
     const dAppClient = new Client(chainId || 'default', writer, reader)
     let privKey
-    if (dappchainPrivateKey === '0x') {
+    if (dappchainPrivateKey === null) {
       privKey = CryptoUtils.generatePrivateKey()
     } else {
       privKey = CryptoUtils.B64ToUint8Array(dappchainPrivateKey)

--- a/src/plasma-cash/user.ts
+++ b/src/plasma-cash/user.ts
@@ -18,9 +18,14 @@ import {
 import { IPlasmaCoin } from './ethereum-client'
 import { sleep, hexBN } from '../helpers'
 import { ethers, providers } from 'ethers'
+import { AddressMapper } from '../contracts/address-mapper'
+import { EthersSigner } from '../solidity-helpers'
 
 const ERC721_ABI = ['function safeTransferFrom(address _from, address _to, uint256 _tokenId)']
-const ERC20_ABI = ['function approve(address spender, uint256 value)', 'function allowance(address owner, address spender)']
+const ERC20_ABI = [
+  'function approve(address spender, uint256 value)',
+  'function allowance(address owner, address spender)'
+]
 // Helper function to create a user instance.
 
 // User friendly wrapper for all Entity related functions, taking advantage of the database
@@ -39,18 +44,19 @@ export class User extends Entity {
     User._contractName = contractName
   }
 
-  static createMetamaskUser(
+  static async createMetamaskUser(
     web3: Web3,
     plasmaAddress: string,
     dappchainEndpoint: string,
     eventsEndpoint: string,
     startBlock?: BN,
     chainId?: string
-  ): User {
+  ): Promise<User> {
     const provider = new ethers.providers.Web3Provider(web3.currentProvider)
     const signer = provider.getSigner()
     return this.createUser(
       signer,
+      '0x',
       plasmaAddress,
       dappchainEndpoint,
       eventsEndpoint,
@@ -60,8 +66,9 @@ export class User extends Entity {
     )
   }
 
-  static createOfflineUser(
+  static async createOfflineUser(
     privateKey: string,
+    dappchainPrivateKey: string,
     endpoint: string,
     plasmaAddress: string,
     dappchainEndpoint: string,
@@ -69,11 +76,12 @@ export class User extends Entity {
     dbPath?: string,
     startBlock?: BN,
     chainId?: string
-  ): User {
+  ): Promise<User> {
     const provider = new ethers.providers.JsonRpcProvider(endpoint)
     const wallet = new ethers.Wallet(privateKey, provider)
     return this.createUser(
       wallet,
+      dappchainPrivateKey,
       plasmaAddress,
       dappchainEndpoint,
       eventsEndpoint,
@@ -83,28 +91,50 @@ export class User extends Entity {
     )
   }
 
-  static createUser(
+  static async createUser(
     wallet: ethers.Signer,
+    dappchainPrivateKey: string,
     plasmaAddress: string,
     dappchainEndpoint: string,
     eventsEndpoint: string,
     dbPath?: string,
     startBlock?: BN,
     chainId?: string
-  ): User {
+  ): Promise<User> {
     const database = new PlasmaDB(dbPath)
     const ethPlasmaClient = new EthereumPlasmaClient(wallet, plasmaAddress, eventsEndpoint)
     const writer = createJSONRPCClient({ protocols: [{ url: dappchainEndpoint + '/rpc' }] })
     const reader = createJSONRPCClient({ protocols: [{ url: dappchainEndpoint + '/query' }] })
     const dAppClient = new Client(chainId || 'default', writer, reader)
-    // TODO: Key should not be generated each time, user should provide their key, or it should be retrieved through some one way mapping
-    const privKey = CryptoUtils.generatePrivateKey()
+    let privKey
+    if (dappchainPrivateKey === '0x') {
+      privKey = CryptoUtils.generatePrivateKey()
+    } else {
+      privKey = CryptoUtils.B64ToUint8Array(dappchainPrivateKey)
+    }
     const pubKey = CryptoUtils.publicKeyFromPrivateKey(privKey)
     dAppClient.txMiddleware = [
       new NonceTxMiddleware(pubKey, dAppClient),
       new SignedTxMiddleware(privKey)
     ]
     const callerAddress = new Address(chainId || 'default', LocalAddress.fromPublicKey(pubKey))
+
+    const addressMapper = await AddressMapper.createAsync(
+      dAppClient,
+      new Address(dAppClient.chainId, LocalAddress.fromPublicKey(pubKey))
+    )
+    const ethAddress = new Address('eth', LocalAddress.fromHexString(await wallet.getAddress()))
+    try {
+      await addressMapper.getMappingAsync(ethAddress)
+    } catch (e) {
+      // Register our address if it's not found
+      await addressMapper.addIdentityMappingAsync(
+        ethAddress,
+        callerAddress,
+        new EthersSigner(wallet)
+      )
+    }
+
     const dAppPlasmaClient = new DAppChainPlasmaClient({
       dAppClient,
       callerAddress,

--- a/src/solidity-helpers.ts
+++ b/src/solidity-helpers.ts
@@ -40,10 +40,10 @@ export class EthersSigner implements IEthereumSigner {
     let flatSig = await this._wallet.signMessage(ethers.utils.arrayify(msg))
     const sig = ethers.utils.splitSignature(flatSig)
     let v = sig.v!
-    if (v === 0 || v === 1 ) {
-        v += 27
+    if (v === 0 || v === 1) {
+      v += 27
     }
-    flatSig = '0x01' + sig.r.slice(2) + sig.s.slice(2) + (v).toString(16)
+    flatSig = '0x01' + sig.r.slice(2) + sig.s.slice(2) + v.toString(16)
     return ethutil.toBuffer(flatSig)
   }
 }

--- a/src/tests/e2e/address-mapper-tests.ts
+++ b/src/tests/e2e/address-mapper-tests.ts
@@ -10,7 +10,7 @@ import {
 } from '../../index'
 import { createTestHttpClient } from '../helpers'
 import { EthersSigner } from '../../solidity-helpers'
-import { ethers } from 'ethers';
+import { ethers } from 'ethers'
 
 // TODO: Need a factory to create connection properly likes plasma-cash test
 function getEthersConnection() {
@@ -25,7 +25,9 @@ async function getClientAndContract(
   addressMapper: Contracts.AddressMapper
   pubKey: Uint8Array
 }> {
-  const privKey = CryptoUtils.B64ToUint8Array("D6XCGyCcDZ5TE22h66AlU+Bn6JqL4RnSl4a09RGU9LfM53JFG/T5GAnC0uiuIIiw9Dl0TwEAmdGb+WE0Bochkg==")
+  const privKey = CryptoUtils.B64ToUint8Array(
+    'D6XCGyCcDZ5TE22h66AlU+Bn6JqL4RnSl4a09RGU9LfM53JFG/T5GAnC0uiuIIiw9Dl0TwEAmdGb+WE0Bochkg=='
+  )
   const pubKey = CryptoUtils.publicKeyFromPrivateKey(privKey)
   const client = createClient()
   client.txMiddleware = createDefaultTxMiddleware(client, privKey)

--- a/src/tests/e2e/plasma-cash/challenge-after-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-after-demo.ts
@@ -1,41 +1,19 @@
 import test from 'tape'
 import Web3 from 'web3'
 import BN from 'bn.js'
-import { PlasmaUser } from '../../..'
+import { setupAccounts } from './config'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import {
-  sleep,
-  ADDRESSES,
-  ACCOUNTS,
-  setupContracts,
-  web3Endpoint,
-  dappchainEndpoint,
-  eventsEndpoint
-} from './config'
+import { ADDRESSES, setupContracts, web3Endpoint } from './config'
 
 export async function runChallengeAfterDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.HttpProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
   const cardsAddress = ADDRESSES.token_contract
 
-  const dan = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.dan,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'dan_db'
-  )
-
-  const mallory = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.mallory,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'mallory_db'
-  )
+  const accounts = await setupAccounts()
+  const mallory = accounts.mallory
+  const dan = accounts.dan
 
   // Give Mallory 5 tokens
   await cards.registerAsync(mallory.ethAddress)

--- a/src/tests/e2e/plasma-cash/challenge-after-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-after-demo.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import Web3 from 'web3'
 import BN from 'bn.js'
-import { setupAccounts } from './config'
+import { setupAccounts, disconnectAccounts } from './config'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
 import { ADDRESSES, setupContracts, web3Endpoint } from './config'
@@ -74,8 +74,7 @@ export async function runChallengeAfterDemo(t: test.Test) {
   const danTokensEnd = await cards.balanceOfAsync(dan.ethAddress)
   t.equal(danTokensEnd.toNumber(), 1, 'END: Dan has correct number of tokens')
 
-  dan.disconnect()
-  mallory.disconnect()
+  disconnectAccounts(accounts)
 
   t.end()
 }

--- a/src/tests/e2e/plasma-cash/challenge-before-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-before-demo.ts
@@ -4,47 +4,17 @@ import Web3 from 'web3'
 import { PlasmaUser } from '../../..'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import {
-  sleep,
-  ADDRESSES,
-  ACCOUNTS,
-  setupContracts,
-  web3Endpoint,
-  dappchainEndpoint,
-  eventsEndpoint
-} from './config'
+import { sleep, ADDRESSES, setupContracts, web3Endpoint, setupAccounts } from './config'
 
 export async function runChallengeBeforeDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.HttpProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
   const cardsAddress = ADDRESSES.token_contract
 
-  const dan = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.dan,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'dan_db'
-  )
-
-  const mallory = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.mallory,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'mallory_db'
-  )
-
-  const trudy = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.trudy,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'trudy_db'
-  )
+  const accounts = await setupAccounts()
+  const dan = accounts.dan
+  const mallory = accounts.mallory
+  const trudy = accounts.trudy
 
   // Give Dan 5 tokens
   await cards.registerAsync(dan.ethAddress)

--- a/src/tests/e2e/plasma-cash/challenge-before-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-before-demo.ts
@@ -1,10 +1,16 @@
 import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
-import { PlasmaUser } from '../../..'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import { sleep, ADDRESSES, setupContracts, web3Endpoint, setupAccounts } from './config'
+import {
+  sleep,
+  ADDRESSES,
+  setupContracts,
+  web3Endpoint,
+  setupAccounts,
+  disconnectAccounts
+} from './config'
 
 export async function runChallengeBeforeDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.HttpProvider(web3Endpoint))
@@ -74,9 +80,7 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   const danTokensEnd = await cards.balanceOfAsync(dan.ethAddress)
   t.equal(danTokensEnd.toNumber(), 6, 'END: Dan has correct number of tokens')
 
-  dan.disconnect()
-  mallory.disconnect()
-  trudy.disconnect()
+  disconnectAccounts(accounts)
 
   t.end()
 }

--- a/src/tests/e2e/plasma-cash/challenge-between-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-between-demo.ts
@@ -1,50 +1,20 @@
 import test from 'tape'
 import Web3 from 'web3'
 import BN from 'bn.js'
-import { PlasmaUser } from '../../..'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import {
-  sleep,
-  ADDRESSES,
-  ACCOUNTS,
-  setupContracts,
-  web3Endpoint,
-  dappchainEndpoint,
-  eventsEndpoint
-} from './config'
+import { sleep, ADDRESSES, setupContracts, web3Endpoint, setupAccounts } from './config'
 
 export async function runChallengeBetweenDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.HttpProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
   const cardsAddress = ADDRESSES.token_contract
 
-  const alice = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.alice,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'alice_db'
-  )
+  const accounts = await setupAccounts()
+  const alice = accounts.alice
+  const bob = accounts.bob
+  const eve = accounts.eve
 
-  const bob = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.bob,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'bob_db'
-  )
-
-  const eve = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.eve,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'eve_db'
-  )
   const bobTokensStart = await cards.balanceOfAsync(bob.ethAddress)
 
   // Give Eve 5 tokens

--- a/src/tests/e2e/plasma-cash/challenge-between-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-between-demo.ts
@@ -3,7 +3,14 @@ import Web3 from 'web3'
 import BN from 'bn.js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import { sleep, ADDRESSES, setupContracts, web3Endpoint, setupAccounts } from './config'
+import {
+  sleep,
+  ADDRESSES,
+  setupContracts,
+  web3Endpoint,
+  setupAccounts,
+  disconnectAccounts
+} from './config'
 
 export async function runChallengeBetweenDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.HttpProvider(web3Endpoint))
@@ -75,9 +82,7 @@ export async function runChallengeBetweenDemo(t: test.Test) {
     'END: Bob has correct number of tokens'
   )
 
-  alice.disconnect()
-  bob.disconnect()
-  eve.disconnect()
+  disconnectAccounts(accounts)
 
   t.end()
 }

--- a/src/tests/e2e/plasma-cash/complex-demo.ts
+++ b/src/tests/e2e/plasma-cash/complex-demo.ts
@@ -9,7 +9,8 @@ import {
   ACCOUNTS,
   web3Endpoint,
   dappchainEndpoint,
-  eventsEndpoint
+  eventsEndpoint,
+  setupAccounts
 } from './config'
 
 import BN from 'bn.js'
@@ -19,24 +20,9 @@ import BN from 'bn.js'
 // All interactions happen in ETH
 export async function complexDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.HttpProvider(web3Endpoint))
-
-  const fred = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.fred,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'fred_db'
-  )
-
-  const greg = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.greg,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'greg_db'
-  )
+  const accounts = await setupAccounts()
+  const greg = accounts.greg
+  const fred = accounts.fred
 
   // Fred deposits 5000 Wei split across 3 coins
   // Greg deposits 1000 Wei split across 3 coins
@@ -99,14 +85,7 @@ export async function complexDemo(t: test.Test) {
   t.equal((await fred.getPlasmaCoinAsync(coin2)).state, 0, 'Fred succesfully challenged Greg')
 
   // Harry joins in the fun
-  const harry = PlasmaUser.createOfflineUser(
-    ACCOUNTS.harry,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'harry_db'
-  )
+  const harry = accounts.harry
   await harry.watchBlocks()
 
   // Previously, coin1 went from DEPOSITED -> EXITING and now is back to DEPOSITED. This should be reflected on the dappchain state as well. Build521 does not reset a coin to DEPOSITED after it is in EXITING and is challenged.

--- a/src/tests/e2e/plasma-cash/complex-demo.ts
+++ b/src/tests/e2e/plasma-cash/complex-demo.ts
@@ -1,17 +1,8 @@
 import test from 'tape'
 import Web3 from 'web3'
-import { PlasmaUser } from '../../..'
 
 import { increaseTime } from './ganache-helpers'
-import {
-  sleep,
-  ADDRESSES,
-  ACCOUNTS,
-  web3Endpoint,
-  dappchainEndpoint,
-  eventsEndpoint,
-  setupAccounts
-} from './config'
+import { sleep, web3Endpoint, setupAccounts, disconnectAccounts } from './config'
 
 import BN from 'bn.js'
 
@@ -279,9 +270,7 @@ export async function complexDemo(t: test.Test) {
   t.equal((await fred.getUserCoinsAsync()).length, 6, 'Withdraw oracle for fred OK')
   t.equal((await harry.getUserCoinsAsync()).length, 0, 'Withdraw oracle for harry OK')
 
-  harry.disconnect()
-  fred.disconnect()
-  greg.disconnect()
+  disconnectAccounts(accounts)
 
   t.end()
 }

--- a/src/tests/e2e/plasma-cash/config.ts
+++ b/src/tests/e2e/plasma-cash/config.ts
@@ -1,7 +1,6 @@
 import Web3 from 'web3'
 import { EthCardsContract } from './cards-contract'
-import { Entity } from '../../..'
-import BN from 'bn.js'
+import { PlasmaUser } from '../../..'
 
 export const DEFAULT_GAS = '3141592'
 export const CHILD_BLOCK_INTERVAL = 1000
@@ -51,4 +50,111 @@ export function setupContracts(web3: Web3): { cards: EthCardsContract } {
   const abi = require('./contracts/cards-abi.json')
   const cards = new EthCardsContract(new web3.eth.Contract(abi, ADDRESSES.token_contract))
   return { cards }
+}
+
+interface Accounts {
+  alice: PlasmaUser
+  bob: PlasmaUser
+  charlie: PlasmaUser
+  dan: PlasmaUser
+  eve: PlasmaUser
+  trudy: PlasmaUser
+  mallory: PlasmaUser
+  greg: PlasmaUser
+  fred: PlasmaUser
+  harry: PlasmaUser
+}
+
+export async function setupAccounts(): Promise<Accounts> {
+  const alice = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.alice,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'alice_db'
+  )
+
+  const bob = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.bob,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'bob_db'
+  )
+
+  const charlie = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.charlie,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'charlie_db'
+  )
+
+  const dan = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.dan,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'dan_db'
+  )
+
+  const eve = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.eve,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'eve_db'
+  )
+
+  const trudy = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.trudy,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'trudy_db'
+  )
+
+  const mallory = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.mallory,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'mallory_db'
+  )
+
+  const greg = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.greg,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'greg_db'
+  )
+
+  const fred = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.fred,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'fred_db'
+  )
+
+  const harry = await PlasmaUser.createOfflineUser(
+    ACCOUNTS.harry,
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    eventsEndpoint,
+    'harry_db'
+  )
+
+  return { alice, bob, charlie, dan, eve, mallory, trudy, greg, fred, harry }
 }

--- a/src/tests/e2e/plasma-cash/config.ts
+++ b/src/tests/e2e/plasma-cash/config.ts
@@ -32,6 +32,19 @@ export const ACCOUNTS = {
   harry: '0x6b9e9cc46d205668eff6eaa0c4ec6375d475e8ebd821bc79cc4239571560df15'
 }
 
+export const DAPPCHAIN_ACCOUNTS = {
+  alice: 'iDAg84PiCWf4kAYzSnKtlu1rU///XpLqJUuimPEoV1Jp+GtLJa+yXdM/nZOZLcbm9CDAvnYMa/SKQeRNi/ciHA==',
+  bob: '3eHnPMZ9J67MT90L5UbFbDm+WYtguxmtGaVeMsebP0h3oS6er8TwYNoFzk5bbXioeehI2Qg2FH0i25CFj6AALw==',
+  charlie: 'DmYcg2tQreOUrljct8fI1IMp/eWxcR02W1O6tLFCgmMhjtTPv8N50ebTTLw0rFm0FsCGgOMHZQb/ZHN33YImtQ==',
+  dan: '24cBLX65S7rutcByV3c7SWHySj7vtEmMxaS4djLsy7z+yxfUutefMTovCMn2s0OJSy9DgNEu1uJUTs2iEVW6lg==',
+  mallory: 'buCpQHL5EHiK9XeogXTykYOpBCLsqba2orCz4CzZ04oQ52tSpIUaHWSKxHUgsVsobOCkE+cWLQKqSv6hoX18SQ==',
+  eve: 'HwDk9DnZ3ALjSmH+K9JmYDZoaIFczVJL5rUfUAMhzL5cgZv8ipxXQsyhNG6FaqIrWKS6FahNsDxlFLlS3/PKGg==',
+  trudy: 'OCaglZBla+uurtHH6PRVL5M8C1L/4F0OO1kNn2O8T8Ry0MW5xk5D8tZHmog5Z1yZ95i8iUyFoeVArgJZbie0oQ==',
+  fred: '0TuAsWkzCj9l1vfcwz9PRVD59rMuBSE9i93ljb3GI73PLjIsZUOyEQv5Gv4sV+iu64QK0DTWA8D9gMCzf0Yo6w==',
+  greg: 'acyxTNkaEQRGtxgwgy0tvRZ7zvz3XlNZY7JghanFhciMbDMH92QjVWdCvoh384FT0D80RP3+ewq4rOm7QRzuOg==',
+  harry: 'r0mWIq9Dmgdfe++v9fquBd4fwNtNP/OoeNqtTpSN3g9+z0yK4T+QAWQsshjMCkCwTp8SYmRVDwaK5/FbDUys4Q=='
+}
+
 export function sleep(ms: any) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
@@ -68,6 +81,7 @@ interface Accounts {
 export async function setupAccounts(): Promise<Accounts> {
   const alice = await PlasmaUser.createOfflineUser(
     ACCOUNTS.alice,
+    DAPPCHAIN_ACCOUNTS.alice,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -77,6 +91,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const bob = await PlasmaUser.createOfflineUser(
     ACCOUNTS.bob,
+    DAPPCHAIN_ACCOUNTS.bob,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -86,6 +101,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const charlie = await PlasmaUser.createOfflineUser(
     ACCOUNTS.charlie,
+    DAPPCHAIN_ACCOUNTS.charlie,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -95,6 +111,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const dan = await PlasmaUser.createOfflineUser(
     ACCOUNTS.dan,
+    DAPPCHAIN_ACCOUNTS.dan,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -104,6 +121,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const eve = await PlasmaUser.createOfflineUser(
     ACCOUNTS.eve,
+    DAPPCHAIN_ACCOUNTS.eve,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -113,6 +131,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const trudy = await PlasmaUser.createOfflineUser(
     ACCOUNTS.trudy,
+    DAPPCHAIN_ACCOUNTS.trudy,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -122,6 +141,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const mallory = await PlasmaUser.createOfflineUser(
     ACCOUNTS.mallory,
+    DAPPCHAIN_ACCOUNTS.mallory,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -131,6 +151,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const greg = await PlasmaUser.createOfflineUser(
     ACCOUNTS.greg,
+    DAPPCHAIN_ACCOUNTS.greg,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -140,6 +161,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const fred = await PlasmaUser.createOfflineUser(
     ACCOUNTS.fred,
+    DAPPCHAIN_ACCOUNTS.fred,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,
@@ -149,6 +171,7 @@ export async function setupAccounts(): Promise<Accounts> {
 
   const harry = await PlasmaUser.createOfflineUser(
     ACCOUNTS.harry,
+    DAPPCHAIN_ACCOUNTS.harry,
     web3Endpoint,
     ADDRESSES.root_chain,
     dappchainEndpoint,

--- a/src/tests/e2e/plasma-cash/config.ts
+++ b/src/tests/e2e/plasma-cash/config.ts
@@ -33,13 +33,17 @@ export const ACCOUNTS = {
 }
 
 export const DAPPCHAIN_ACCOUNTS = {
-  alice: 'iDAg84PiCWf4kAYzSnKtlu1rU///XpLqJUuimPEoV1Jp+GtLJa+yXdM/nZOZLcbm9CDAvnYMa/SKQeRNi/ciHA==',
+  alice:
+    'iDAg84PiCWf4kAYzSnKtlu1rU///XpLqJUuimPEoV1Jp+GtLJa+yXdM/nZOZLcbm9CDAvnYMa/SKQeRNi/ciHA==',
   bob: '3eHnPMZ9J67MT90L5UbFbDm+WYtguxmtGaVeMsebP0h3oS6er8TwYNoFzk5bbXioeehI2Qg2FH0i25CFj6AALw==',
-  charlie: 'DmYcg2tQreOUrljct8fI1IMp/eWxcR02W1O6tLFCgmMhjtTPv8N50ebTTLw0rFm0FsCGgOMHZQb/ZHN33YImtQ==',
+  charlie:
+    'DmYcg2tQreOUrljct8fI1IMp/eWxcR02W1O6tLFCgmMhjtTPv8N50ebTTLw0rFm0FsCGgOMHZQb/ZHN33YImtQ==',
   dan: '24cBLX65S7rutcByV3c7SWHySj7vtEmMxaS4djLsy7z+yxfUutefMTovCMn2s0OJSy9DgNEu1uJUTs2iEVW6lg==',
-  mallory: 'buCpQHL5EHiK9XeogXTykYOpBCLsqba2orCz4CzZ04oQ52tSpIUaHWSKxHUgsVsobOCkE+cWLQKqSv6hoX18SQ==',
+  mallory:
+    'buCpQHL5EHiK9XeogXTykYOpBCLsqba2orCz4CzZ04oQ52tSpIUaHWSKxHUgsVsobOCkE+cWLQKqSv6hoX18SQ==',
   eve: 'HwDk9DnZ3ALjSmH+K9JmYDZoaIFczVJL5rUfUAMhzL5cgZv8ipxXQsyhNG6FaqIrWKS6FahNsDxlFLlS3/PKGg==',
-  trudy: 'OCaglZBla+uurtHH6PRVL5M8C1L/4F0OO1kNn2O8T8Ry0MW5xk5D8tZHmog5Z1yZ95i8iUyFoeVArgJZbie0oQ==',
+  trudy:
+    'OCaglZBla+uurtHH6PRVL5M8C1L/4F0OO1kNn2O8T8Ry0MW5xk5D8tZHmog5Z1yZ95i8iUyFoeVArgJZbie0oQ==',
   fred: '0TuAsWkzCj9l1vfcwz9PRVD59rMuBSE9i93ljb3GI73PLjIsZUOyEQv5Gv4sV+iu64QK0DTWA8D9gMCzf0Yo6w==',
   greg: 'acyxTNkaEQRGtxgwgy0tvRZ7zvz3XlNZY7JghanFhciMbDMH92QjVWdCvoh384FT0D80RP3+ewq4rOm7QRzuOg==',
   harry: 'r0mWIq9Dmgdfe++v9fquBd4fwNtNP/OoeNqtTpSN3g9+z0yK4T+QAWQsshjMCkCwTp8SYmRVDwaK5/FbDUys4Q=='
@@ -76,6 +80,19 @@ interface Accounts {
   greg: PlasmaUser
   fred: PlasmaUser
   harry: PlasmaUser
+}
+
+export function disconnectAccounts(accounts: Accounts) {
+  accounts.alice.disconnect()
+  accounts.bob.disconnect()
+  accounts.charlie.disconnect()
+  accounts.dan.disconnect()
+  accounts.eve.disconnect()
+  accounts.trudy.disconnect()
+  accounts.mallory.disconnect()
+  accounts.greg.disconnect()
+  accounts.fred.disconnect()
+  accounts.harry.disconnect()
 }
 
 export async function setupAccounts(): Promise<Accounts> {

--- a/src/tests/e2e/plasma-cash/demo.ts
+++ b/src/tests/e2e/plasma-cash/demo.ts
@@ -1,7 +1,13 @@
 import test from 'tape'
 import Web3 from 'web3'
 import { increaseTime } from './ganache-helpers'
-import { ADDRESSES, setupContracts, web3Endpoint, setupAccounts } from './config'
+import {
+  ADDRESSES,
+  setupContracts,
+  web3Endpoint,
+  setupAccounts,
+  disconnectAccounts
+} from './config'
 import BN from 'bn.js'
 
 // Alice registers and has 5 coins, and she deposits 3 of them.
@@ -111,9 +117,7 @@ export async function runDemo(t: test.Test) {
   balance = await cards.balanceOfAsync(charlie.ethAddress)
   t.equal(balance.toNumber(), 1, 'charlie should have 1 token in cards contract')
 
-  alice.disconnect()
-  bob.disconnect()
-  charlie.disconnect()
+  disconnectAccounts(accounts)
 
   t.end()
 }

--- a/src/tests/e2e/plasma-cash/demo.ts
+++ b/src/tests/e2e/plasma-cash/demo.ts
@@ -1,16 +1,7 @@
 import test from 'tape'
 import Web3 from 'web3'
-import { PlasmaUser } from '../../..'
-
 import { increaseTime } from './ganache-helpers'
-import {
-  ADDRESSES,
-  ACCOUNTS,
-  setupContracts,
-  web3Endpoint,
-  dappchainEndpoint,
-  eventsEndpoint
-} from './config'
+import { ADDRESSES, setupContracts, web3Endpoint, setupAccounts } from './config'
 import BN from 'bn.js'
 
 // Alice registers and has 5 coins, and she deposits 3 of them.
@@ -23,35 +14,12 @@ export async function runDemo(t: test.Test) {
   const { cards } = setupContracts(web3)
   const cardsAddress = ADDRESSES.token_contract
 
-  const alice = PlasmaUser.createOfflineUser(
-    ACCOUNTS.alice,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'alice_db'
-  )
-
-  const bob = PlasmaUser.createOfflineUser(
-    ACCOUNTS.bob,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'bob_db'
-  )
-
-  const charlie = PlasmaUser.createOfflineUser(
-    ACCOUNTS.charlie,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'charlie_db'
-  )
+  const accounts = await setupAccounts()
+  const alice = accounts.alice
+  const bob = accounts.bob
+  const charlie = accounts.charlie
 
   await cards.registerAsync(alice.ethAddress)
-
   let balance = await cards.balanceOfAsync(alice.ethAddress)
   t.equal(balance.toNumber(), 5)
 

--- a/src/tests/e2e/plasma-cash/respond-challenge-before-demo.ts
+++ b/src/tests/e2e/plasma-cash/respond-challenge-before-demo.ts
@@ -11,7 +11,8 @@ import {
   setupContracts,
   web3Endpoint,
   dappchainEndpoint,
-  eventsEndpoint
+  eventsEndpoint,
+  setupAccounts
 } from './config'
 
 export async function runRespondChallengeBeforeDemo(t: test.Test) {
@@ -19,30 +20,15 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   const { cards } = setupContracts(web3)
   const cardsAddress = ADDRESSES.token_contract
 
-  const dan = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.dan,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'dan_db'
-  )
-
-  const trudy = await PlasmaUser.createOfflineUser(
-    ACCOUNTS.trudy,
-    web3Endpoint,
-    ADDRESSES.root_chain,
-    dappchainEndpoint,
-    eventsEndpoint,
-    'trudy_db'
-  )
+  const accounts = await setupAccounts()
+  const dan = accounts.dan
+  const trudy = accounts.trudy
 
   // Give Trudy 5 tokens
   await cards.registerAsync(trudy.ethAddress)
   let balance = await cards.balanceOfAsync(trudy.ethAddress)
   t.equal(balance.toNumber(), 5)
 
-  const startBlockNum = await web3.eth.getBlockNumber()
   // Trudy deposits a coin
   await trudy.depositERC721Async(new BN(21), cardsAddress)
 

--- a/src/tests/e2e/plasma-cash/respond-challenge-before-demo.ts
+++ b/src/tests/e2e/plasma-cash/respond-challenge-before-demo.ts
@@ -1,18 +1,15 @@
 import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
-import { PlasmaUser } from '../../..'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
 import {
   sleep,
   ADDRESSES,
-  ACCOUNTS,
   setupContracts,
   web3Endpoint,
-  dappchainEndpoint,
-  eventsEndpoint,
-  setupAccounts
+  setupAccounts,
+  disconnectAccounts
 } from './config'
 
 export async function runRespondChallengeBeforeDemo(t: test.Test) {
@@ -70,8 +67,7 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   // 1 in this demo and 1 in a previous one.
   t.equal(danTokensEnd.toNumber(), 7, 'END: Dan has correct number of tokens')
 
-  dan.disconnect()
-  trudy.disconnect()
+  disconnectAccounts(accounts)
 
   t.end()
 }


### PR DESCRIPTION
- Adds `setupAccounts`, `disconnectAccounts` methods for easier testing with multiple accounts
- Register eth/dappchain keypair to the address mapper during creation if it does not exist
- createUser takes a `dappchainPrivateKey` argument. For `createMetamaskUser` this should be modified to be the private key taken from the `localstorage`. If a user is not registered in the address mapper, they'll be prompted by Metamask to sign a message to register them

This adds some extra burden for users because they need to manage 2 keys, but it's a requirement for security. 