### PR TITLE
Coin history fix

### DIFF
--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 
-export BUILD_NUMBER=595
+export BUILD_NUMBER=607
 
 bash e2e_tests.sh
 bash e2e_plasma_cash_test.sh

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -390,13 +390,21 @@ export class Entity {
 
   async verifyCoinHistoryAsync(slot: BN, proofs: IProofs): Promise<boolean> {
     // Check inclusion proofs
+    const coin = await this.getPlasmaCoinAsync(slot)
+    let earliestValidBlock = coin.depositBlockNum
     for (let p in proofs.inclusion) {
       const blockNumber = new BN(p)
       const tx = proofs.transactions[p] // get the block number from the proof of inclusion and get the tx from that
       const root = await this.getBlockRootAsync(blockNumber)
       const included = await this.checkInclusionAsync(tx, root, slot, proofs.inclusion[p])
-      if (!included) {
-        return false
+      if (included) {
+        // Skip deposit blocks
+        if (tx.prevBlockNum.eq(new BN(0))) { continue }
+        if (tx.prevBlockNum.eq(earliestValidBlock)) {
+          earliestValidBlock = blockNumber
+        } else {
+          return false
+        }
       }
     }
 

--- a/src/plasma-cash/entity.ts
+++ b/src/plasma-cash/entity.ts
@@ -399,7 +399,9 @@ export class Entity {
       const included = await this.checkInclusionAsync(tx, root, slot, proofs.inclusion[p])
       if (included) {
         // Skip deposit blocks
-        if (tx.prevBlockNum.eq(new BN(0))) { continue }
+        if (tx.prevBlockNum.eq(new BN(0))) {
+          continue
+        }
         if (tx.prevBlockNum.eq(earliestValidBlock)) {
           earliestValidBlock = blockNumber
         } else {

--- a/src/tests/e2e/plasma-cash/challenge-between-demo.ts
+++ b/src/tests/e2e/plasma-cash/challenge-between-demo.ts
@@ -48,6 +48,7 @@ export async function runChallengeBetweenDemo(t: test.Test) {
 
   // Alice attempts to exit her double-spent coin
   // Low level call to exit the double spend
+  t.equal(await alice.receiveAndWatchCoinAsync(deposit1Slot), false, 'Alice accepted faux coin')
   await alice.startExitAsync({
     slot: deposit1Slot,
     prevBlockNum: coin.depositBlockNum,


### PR DESCRIPTION
Closes https://github.com/loomnetwork/loom-js/issues/156, now checks that the previous block of a transaction is the last included block. This makes users reject coins that have double spends in their history