### PR TITLE
Fix nonce mismatch error detection

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -289,7 +289,7 @@ export class Client extends EventEmitter {
         }
         if (
           result.check_tx.code === 1 &&
-          result.check_tx.log === 'sequence number does not match'
+          result.check_tx.log.indexOf('sequence number does not match') !== -1
         ) {
           throw new Error(INVALID_TX_NONCE_ERROR)
         }


### PR DESCRIPTION
The error message is now more verbose in recent loom builds.