### PR TITLE
Poll for tx results instead of waiting for the node to commit tx

### DIFF
--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 
-export BUILD_NUMBER=653
+export BUILD_NUMBER=690
 
 bash e2e_tests.sh
 bash e2e_plasma_cash_test.sh

--- a/e2e_tests.sh
+++ b/e2e_tests.sh
@@ -63,8 +63,14 @@ start_chains() {
 }
 
 stop_chains() {
-  kill -9 $GANACHE_PID
-  kill -9 $LOOM_PID
+  if [[ -n "$GANACHE_PID" ]]; then
+    kill -9 $GANACHE_PID
+    GANACHE_PID=""
+  fi
+  if [[ -n "$LOOM_PID" ]]; then
+    kill -9 $LOOM_PID
+    LOOM_PID=""
+  fi
   pkill -f "${LOOM_DIR}/contracts/blueprint.0.0.1" || true
 }
 
@@ -92,6 +98,9 @@ trap cleanup EXIT
 
 start_chains
 run_tests
+cleanup
+
+sleep 1
 
 if [ "${TRAVIS:-}" ]; then
   rm -rf $LOOM_DIR

--- a/src/client.ts
+++ b/src/client.ts
@@ -263,7 +263,7 @@ export class Client extends EventEmitter {
   ) {
     super()
     this.chainId = chainId
-    this.txBroadcaster = new TxSyncBroadcaster()
+    this.txBroadcaster = new TxCommitBroadcaster()
 
     // TODO: basic validation of the URIs to ensure they have all required components.
     this._writeClient =

--- a/src/client.ts
+++ b/src/client.ts
@@ -176,7 +176,9 @@ export class TxSyncBroadcaster implements ITxBroadcaster {
       op.attempt((currentAttempt: number) => {
         debugLog(`Querying for result of tx ${checkTxResult.hash} - attempt ${currentAttempt}`)
         client
-          .sendAsync<ITxQueryResult>('tx', { hash: checkTxResult.hash })
+          .sendAsync<ITxQueryResult>('tx', {
+            hash: Buffer.from(checkTxResult.hash, 'hex').toString('base64')
+          })
           .then(result => {
             resolve(result)
           })

--- a/src/client.ts
+++ b/src/client.ts
@@ -263,7 +263,7 @@ export class Client extends EventEmitter {
   ) {
     super()
     this.chainId = chainId
-    this.txBroadcaster = new TxCommitBroadcaster()
+    this.txBroadcaster = new TxSyncBroadcaster()
 
     // TODO: basic validation of the URIs to ensure they have all required components.
     this._writeClient =

--- a/src/tests/e2e/loom-provider-eth-get-logs.ts
+++ b/src/tests/e2e/loom-provider-eth-get-logs.ts
@@ -4,6 +4,7 @@ import { LocalAddress, CryptoUtils } from '../../index'
 import { createTestClient, execAndWaitForMillisecondsAsync } from '../helpers'
 import { LoomProvider } from '../../loom-provider'
 import { deployContract } from '../evm-helpers'
+import { numberToHex } from '../../crypto-utils'
 
 /**
  * Requires the SimpleStore solidity contract deployed on a loomchain.
@@ -112,26 +113,32 @@ async function testGetLogsLatest(t: test.Test, loomProvider: LoomProvider, fromA
 }
 
 async function testGetLogsAny(t: test.Test, loomProvider: LoomProvider, fromAddr: string) {
+  const curBlock = await (loomProvider as any)._client.getBlockHeightAsync()
+  console.log(`current block: ${curBlock}`)
+  const fromBlock = numberToHex(parseInt(curBlock, 10) + 1)
   await newTransactionToSetState(loomProvider, fromAddr)
 
   // Filtering to get logs
   let ethGetLogs = await loomProvider.sendAsync({
     id: 5,
     method: 'eth_getLogs',
-    params: []
+    params: [{ fromBlock }]
   })
 
   t.equal(ethGetLogs.result.length, 1, 'Should return one log for anything filter')
 }
 
 async function testGetLogsAnyPending(t: test.Test, loomProvider: LoomProvider, fromAddr: string) {
+  const curBlock = await (loomProvider as any)._client.getBlockHeightAsync()
+  console.log(`current block: ${curBlock}`)
+  const fromBlock = numberToHex(parseInt(curBlock, 10) + 1)
   await newTransactionToSetState(loomProvider, fromAddr)
 
   // Filtering to get logs
   let ethGetLogs = await loomProvider.sendAsync({
     id: 6,
     method: 'eth_getLogs',
-    params: [{ toBlock: 'pending' }]
+    params: [{ fromBlock, toBlock: 'pending' }]
   })
 
   t.equal(ethGetLogs.result.length, 1, 'Should return one log for anything pending filter')


### PR DESCRIPTION
The client now sends txs to the `broadcast_tx_sync` endpoint by default and then polls the node for the result (assuming the tx passed CheckTx).

Probably need to tweak the retry options that control the polling behavior.

