### PR TITLE
Fix CachedNonceTxMiddleware to increment nonce only for valid/successful txs

### DIFF
--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 
-export BUILD_NUMBER=690
+export BUILD_NUMBER=703
 
 bash e2e_tests.sh
 bash e2e_plasma_cash_test.sh

--- a/src/middleware/cached-nonce-tx-middleware.ts
+++ b/src/middleware/cached-nonce-tx-middleware.ts
@@ -63,6 +63,7 @@ export class CachedNonceTxMiddleware implements ITxMiddlewareHandler {
         throw new Error(INVALID_TX_NONCE_ERROR)
       }
     } else if (this._lastNonce !== null) {
+      // Only increment the nonce if the tx is valid
       this._lastNonce++
     }
     return results

--- a/src/middleware/cached-nonce-tx-middleware.ts
+++ b/src/middleware/cached-nonce-tx-middleware.ts
@@ -4,7 +4,7 @@ import { ITxMiddlewareHandler, Client, ITxResults } from '../client'
 import { bytesToHex } from '../crypto-utils'
 import { INVALID_TX_NONCE_ERROR } from './nonce-tx-middleware'
 
-const log = debug('nonce-tx-middleware')
+const log = debug('cached-nonce-tx-middleware')
 
 /**
  * Wraps data in a NonceTx.

--- a/src/middleware/cached-nonce-tx-middleware.ts
+++ b/src/middleware/cached-nonce-tx-middleware.ts
@@ -34,29 +34,36 @@ export class CachedNonceTxMiddleware implements ITxMiddlewareHandler {
       }
     }
 
-    this._lastNonce++
-    log(`Next nonce ${this._lastNonce}`)
+    log(`Next nonce ${this._lastNonce + 1}`)
 
     const tx = new NonceTx()
     tx.setInner(txData as Uint8Array)
-    tx.setSequence(this._lastNonce)
+    tx.setSequence(this._lastNonce + 1)
     return tx.serializeBinary()
   }
 
   HandleResults(results: ITxResults): ITxResults {
     const { validation, commit } = results
-    const isCheckTxNonceInvalid =
-      validation &&
-      validation.code === 1 &&
-      (validation.log && validation.log.indexOf('sequence number does not match') !== -1)
-    const isDeliverTxNonceInvalid =
-      commit &&
-      commit.code === 1 &&
-      (commit.log && commit.log.indexOf('sequence number does not match') !== -1)
-
-    if (isCheckTxNonceInvalid || isDeliverTxNonceInvalid) {
+    const isInvalidTx = validation && validation.code !== 0
+    const isFailedTx = commit && commit.code !== 0
+    if (isInvalidTx || isFailedTx) {
+      // Nonce has to be reset regardless of the cause of the tx failure.
       this._lastNonce = null
-      throw new Error(INVALID_TX_NONCE_ERROR)
+      // Throw a specific error for a nonce mismatch
+      const isCheckTxNonceInvalid =
+        validation &&
+        validation.code === 1 &&
+        (validation.log && validation.log.indexOf('sequence number does not match') !== -1)
+      const isDeliverTxNonceInvalid =
+        commit &&
+        commit.code === 1 &&
+        (commit.log && commit.log.indexOf('sequence number does not match') !== -1)
+
+      if (isCheckTxNonceInvalid || isDeliverTxNonceInvalid) {
+        throw new Error(INVALID_TX_NONCE_ERROR)
+      }
+    } else if (this._lastNonce !== null) {
+      this._lastNonce++
     }
     return results
   }

--- a/src/plasma-cash/user.ts
+++ b/src/plasma-cash/user.ts
@@ -175,7 +175,7 @@ export class User extends Entity {
     })
     const coin = await this.getCoinFromTxAsync(tx)
     currentBlock = await this.pollForBlockChange(currentBlock, 20, 2000)
-    this.receiveAndWatchCoinAsync(coin.slot)
+    await this.receiveAndWatchCoinAsync(coin.slot)
     return coin
   }
 
@@ -190,7 +190,7 @@ export class User extends Entity {
     )
     const coin = await this.getCoinFromTxAsync(tx)
     currentBlock = await this.pollForBlockChange(currentBlock, 20, 2000)
-    this.receiveAndWatchCoinAsync(coin.slot)
+    await this.receiveAndWatchCoinAsync(coin.slot)
     return coin
   }
 
@@ -210,7 +210,7 @@ export class User extends Entity {
     const tx = await this.plasmaCashContract.depositERC20(amount.toString(), address)
     const coin = await this.getCoinFromTxAsync(tx)
     currentBlock = await this.pollForBlockChange(currentBlock, 20, 2000)
-    this.receiveAndWatchCoinAsync(coin.slot)
+    await this.receiveAndWatchCoinAsync(coin.slot)
     return coin
   }
 
@@ -282,7 +282,7 @@ export class User extends Entity {
             await this.getPlasmaTxAsync(coin.slot, blk) // this will add the coin to state
             // TODO: If a new block arrives and we have the coin already in state but are not watching for its exits, e.g. after restarting the client, we need to start watching again.
           } else {
-            this.receiveAndWatchCoinAsync(coin.slot)
+            await this.receiveAndWatchCoinAsync(coin.slot)
           }
         }
       })

--- a/src/tests/e2e/client-test-tx-cache.ts
+++ b/src/tests/e2e/client-test-tx-cache.ts
@@ -207,7 +207,7 @@ test('Client tx already in cache error (HTTP)', async t => {
   t.end()
 })
 
-test.only('Test CachedNonceTxMiddleware', async t => {
+test('Test CachedNonceTxMiddleware', async t => {
   const address = await deploySimpleStoreContract()
 
   let client = createTestHttpClient()

--- a/src/tests/e2e/client-test-tx-cache.ts
+++ b/src/tests/e2e/client-test-tx-cache.ts
@@ -218,8 +218,7 @@ test.only('Test CachedNonceTxMiddleware', async t => {
 
     // Middleware used for client
     client.txMiddleware = [
-      //new CachedNonceTxMiddleware(publicKey, client),
-      new NonceTxMiddleware(publicKey, client),
+      new CachedNonceTxMiddleware(publicKey, client),
       new SignedTxMiddleware(privateKey)
     ]
 

--- a/src/tests/e2e/client-test-tx-cache.ts
+++ b/src/tests/e2e/client-test-tx-cache.ts
@@ -218,7 +218,8 @@ test.only('Test CachedNonceTxMiddleware', async t => {
 
     // Middleware used for client
     client.txMiddleware = [
-      new CachedNonceTxMiddleware(publicKey, client),
+      //new CachedNonceTxMiddleware(publicKey, client),
+      new NonceTxMiddleware(publicKey, client),
       new SignedTxMiddleware(privateKey)
     ]
 

--- a/src/tests/e2e/client-test-tx-cache.ts
+++ b/src/tests/e2e/client-test-tx-cache.ts
@@ -237,14 +237,17 @@ test.only('Test CachedNonceTxMiddleware', async t => {
 
     let cacheErrCount = 0
     try {
+      // Should revert because the value is 100
       await callTransactionAsync(client, caller, address, functionSetErr)
     } catch (err) {
       cacheErrCount++
     }
 
     try {
+      // Should not fail
       await callTransactionAsync(client, caller, address, functionSetOk)
     } catch (err) {
+      console.error(err)
       cacheErrCount++
     }
 

--- a/src/tests/e2e/client-test-tx-cache.ts
+++ b/src/tests/e2e/client-test-tx-cache.ts
@@ -5,15 +5,15 @@ import {
   SignedTxMiddleware,
   CryptoUtils,
   Client,
-  isTxAlreadyInCacheError,
   ITxMiddlewareHandler
 } from '../../index'
-import { createTestWSClient, waitForMillisecondsAsync, createTestHttpClient } from '../helpers'
+import { createTestWSClient, createTestHttpClient } from '../helpers'
 import { CallTx, VMType, MessageTx, Transaction, NonceTx } from '../../proto/loom_pb'
 import { LoomProvider } from '../../loom-provider'
 import { deployContract } from '../evm-helpers'
 import { bufferToProtobufBytes } from '../../crypto-utils'
 import { Address, LocalAddress } from '../../address'
+import { CachedNonceTxMiddleware } from '../../middleware'
 
 /**
  * Requires the SimpleStore solidity contract deployed on a loomchain.
@@ -33,6 +33,9 @@ import { Address, LocalAddress } from '../../address'
  *
  *   function set(uint _value) public {
  *     value = _value;
+ *
+ *     require(_value != 100, "Magic value");
+ *
  *     emit NewValueSet(value);
  *   }
  *
@@ -60,7 +63,7 @@ async function deploySimpleStoreContract(): Promise<Address> {
 
     // Contract bytecode to deploy
     const contractData =
-      '608060405234801561001057600080fd5b50600a60005561015c806100256000396000f3006080604052600436106100565763ffffffff7c010000000000000000000000000000000000000000000000000000000060003504166360fe47b1811461005b5780636d4ce63c14610075578063cf7189211461009c575b600080fd5b34801561006757600080fd5b506100736004356100b4565b005b34801561008157600080fd5b5061008a6100ef565b60408051918252519081900360200190f35b3480156100a857600080fd5b506100736004356100f5565b60008190556040805182815290517fb922f092a64f1a076de6f21e4d7c6400b6e55791cc935e7bb8e7e90f7652f15b9181900360200190a150565b60005490565b60008190556040805182815290517fc151b22f26f815d64ae384647d49bc5655149c4b273318d8c3846086dae3835e9181900360200190a1505600a165627a7a723058206e4e5f5b6acc54b18ad15cb2110379c386cd8327527ca2d203a563300b37e3890029'
+      '608060405234801561001057600080fd5b50600a600081905550610201806100286000396000f300608060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b11461005c5780636d4ce63c14610089578063cf718921146100b4575b600080fd5b34801561006857600080fd5b50610087600480360381019080803590602001909291905050506100e1565b005b34801561009557600080fd5b5061009e610193565b6040518082815260200191505060405180910390f35b3480156100c057600080fd5b506100df6004803603810190808035906020019092919050505061019c565b005b8060008190555060648114151515610161576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600b8152602001807f4d616769632076616c756500000000000000000000000000000000000000000081525060200191505060405180910390fd5b6000547fb922f092a64f1a076de6f21e4d7c6400b6e55791cc935e7bb8e7e90f7652f15b60405160405180910390a250565b60008054905090565b806000819055506000547fc151b22f26f815d64ae384647d49bc5655149c4b273318d8c3846086dae3835e60405160405180910390a2505600a165627a7a723058204c7af9b8100ac44b72d5498cd5d9034844c7b2249060740bafbe2876fbbcb6d40029'
 
     // Deploy
     const result = await deployContract(loomProvider, contractData)
@@ -192,6 +195,60 @@ test('Client tx already in cache error (HTTP)', async t => {
       cacheErrCount++
     }
     t.equal(cacheErrCount, 1, 'expect to receive cache error')
+  } catch (err) {
+    console.error(err)
+    t.fail(err.message)
+  }
+
+  if (client) {
+    client.disconnect()
+  }
+
+  t.end()
+})
+
+test.only('Test CachedNonceTxMiddleware', async t => {
+  const address = await deploySimpleStoreContract()
+
+  let client = createTestHttpClient()
+
+  try {
+    const privateKey = CryptoUtils.generatePrivateKey()
+    const publicKey = CryptoUtils.publicKeyFromPrivateKey(privateKey)
+
+    // Middleware used for client
+    client.txMiddleware = [
+      new CachedNonceTxMiddleware(publicKey, client),
+      new SignedTxMiddleware(privateKey)
+    ]
+
+    const caller = new Address('default', LocalAddress.fromPublicKey(publicKey))
+
+    // Reverts when value is 100 (64 hex)
+    const functionSetErr = Buffer.from(
+      '60fe47b10000000000000000000000000000000000000000000000000000000000000064',
+      'hex'
+    )
+
+    const functionSetOk = Buffer.from(
+      '60fe47b1000000000000000000000000000000000000000000000000000000000000000f',
+      'hex'
+    )
+
+    let cacheErrCount = 0
+    try {
+      await callTransactionAsync(client, caller, address, functionSetErr)
+    } catch (err) {
+      cacheErrCount++
+    }
+
+    try {
+      await callTransactionAsync(client, caller, address, functionSetOk)
+    } catch (err) {
+      cacheErrCount++
+    }
+
+    t.equal(cacheErrCount, 1, 'expect to receive only one cache error')
   } catch (err) {
     console.error(err)
     t.fail(err.message)


### PR DESCRIPTION
The cached nonce in `CachedNonceTxMiddleware` was previously incremented regardless of whether or not the tx was valid and/or successful, this caused the tx after a failed tx to fail even when it should've succeeded. The cached nonce is now only incremented once it is known that the last tx that was sent is valid, though whether or not a tx was actually successful is only known when using the `TxCommitBroadcaster` (which is no longer the default broadcaster).

The cached nonce is also re-synced with the node whenever a tx fails (though that may need to be tweaked some more to handle TM errors). 