### PR TITLE
Query nonce from write URL instead of read URL 

### DIFF
--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 
-export BUILD_ID=nonce-on-write-url
+export BUILD_ID=build-726
 
 bash e2e_tests.sh
-#bash e2e_plasma_cash_test.sh
+bash e2e_plasma_cash_test.sh

--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -7,4 +7,4 @@ eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 export BUILD_ID=nonce-on-write-url
 
 bash e2e_tests.sh
-bash e2e_plasma_cash_test.sh
+#bash e2e_plasma_cash_test.sh

--- a/.travis_e2e_test.sh
+++ b/.travis_e2e_test.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 eval "$(GIMME_GO_VERSION=1.10.2 gimme)"
 
-export BUILD_NUMBER=703
+export BUILD_ID=nonce-on-write-url
 
 bash e2e_tests.sh
 bash e2e_plasma_cash_test.sh

--- a/e2e_plasma_cash_test.sh
+++ b/e2e_plasma_cash_test.sh
@@ -95,9 +95,9 @@ function cleanup {
 function download_dappchain {
     cd $LOOM_DIR
     if [[ "`uname`" == 'Darwin' ]]; then
-        wget https://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/loom
-    else 
-        wget https://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/loom
+        wget https://private.delegatecall.com/loom/osx/$BUILD_ID/loom
+    else
+        wget https://private.delegatecall.com/loom/linux/$BUILD_ID/loom
     fi
     chmod +x loom
     export LOOM_BIN=`pwd`/loom

--- a/e2e_tests.sh
+++ b/e2e_tests.sh
@@ -28,7 +28,7 @@ fi
 
 download_dappchain() {
   cd $LOOM_DIR
-  wget https://private.delegatecall.com/loom/$PLATFORM/build-$BUILD_NUMBER/loom
+  wget https://private.delegatecall.com/loom/$PLATFORM/$BUILD_ID/loom
   chmod +x loom
   LOOM_BIN=`pwd`/loom
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -690,7 +690,7 @@ export class Client extends EventEmitter {
    * @return The nonce.
    */
   async getNonceAsync(key: string): Promise<number> {
-    return parseInt(await this._readClient.sendAsync<string>('nonce', { key }), 10)
+    return parseInt(await this._writeClient.sendAsync<string>('nonce', { key }), 10)
   }
 
   /**


### PR DESCRIPTION
This makes it possible to create a single client that sends txs to a validator node, and sends all other queries to a non-validator node.