### PR TITLE
Override read URL for PlasmaChain production cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: required
 node_js:
-  - node
+  - "8.9.1"
 go:
   - 1.10.2
 cache:

--- a/src/client.ts
+++ b/src/client.ts
@@ -762,8 +762,8 @@ export class Client extends EventEmitter {
   }
 }
 
-function overrideReadURL(
-  writeClient?: IJSONRPCClient | string,
+export function overrideReadURL(
+  writeClient: IJSONRPCClient | string,
   readClient?: IJSONRPCClient | string
 ): IJSONRPCClient | string | undefined {
   if (typeof readClient === 'string') {

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,6 @@ import debug from 'debug'
 import { Message } from 'google-protobuf'
 import EventEmitter from 'events'
 import retry from 'retry'
-import * as url from 'url'
 
 import { VMType } from './proto/loom_pb'
 import {
@@ -18,7 +17,7 @@ import { Uint8ArrayToB64, B64ToUint8Array, bufferToProtobufBytes } from './crypt
 import { Address, LocalAddress } from './address'
 import { WSRPCClient, IJSONRPCEvent } from './internal/ws-rpc-client'
 import { RPCClientEvent, IJSONRPCClient } from './internal/json-rpc-client'
-import { sleep } from './helpers'
+import { sleep, parseUrl } from './helpers'
 
 export interface ITxHandlerResult {
   code?: number
@@ -766,7 +765,7 @@ export class Client extends EventEmitter {
 }
 
 export function overrideReadUrl(readUrl: string): string {
-  const origUrl = new url.URL(readUrl)
+  const origUrl = parseUrl(readUrl)
   if (origUrl.hostname === 'plasma.dappchains.com') {
     origUrl.hostname = 'plasma-readonly.dappchains.com'
     return origUrl.toString()

--- a/src/client.ts
+++ b/src/client.ts
@@ -291,11 +291,8 @@ export class Client extends EventEmitter {
     if (!readClient || writeClient === readClient) {
       this._readClient = this._writeClient
     } else {
-      if (typeof readClient === 'string') {
-        this._readClient = new WSRPCClient(overrideReadUrl(readClient))
-      } else {
-        this._readClient = readClient
-      }
+      this._readClient =
+        typeof readClient === 'string' ? new WSRPCClient(overrideReadUrl(readClient)) : readClient
       this._readClient.on(RPCClientEvent.Error, (url: string, err: any) =>
         this._emitNetEvent(url, ClientEvent.Error, err)
       )

--- a/src/dpos/dpos-user.ts
+++ b/src/dpos/dpos-user.ts
@@ -1,4 +1,7 @@
 import BN from 'bn.js'
+import debug from 'debug'
+import { ethers, ContractTransaction } from 'ethers'
+import Web3 from 'web3'
 
 import {
   CryptoUtils,
@@ -12,9 +15,6 @@ import {
   EthersSigner
 } from '..'
 import { JSONRPCProtocol } from '../internal/json-rpc-client'
-
-import { ethers, ContractTransaction } from 'ethers'
-import Web3 from 'web3'
 import { DPOS2, Coin, LoomCoinTransferGateway, AddressMapper } from '../contracts'
 import { IWithdrawalReceipt } from '../contracts/transfer-gateway'
 import { sleep } from '../helpers'
@@ -26,8 +26,8 @@ import {
   ITotalDelegation
 } from '../contracts/dpos2'
 import { selectProtocol } from '../rpc-client-factory'
+import { overrideReadURL } from '../client'
 
-import debug from 'debug'
 const log = debug('dpos-user')
 
 const coinMultiplier = new BN(10).pow(new BN(18))
@@ -106,7 +106,7 @@ export class DPOSUser {
       protocols: [{ url: dappchainEndpoint + writerSuffix }]
     })
     const reader = createJSONRPCClient({
-      protocols: [{ url: dappchainEndpoint + readerSuffix }]
+      protocols: [{ url: overrideReadURL(dappchainEndpoint + readerSuffix) as string }]
     })
 
     const client = new Client(chainId, writer, reader)

--- a/src/dpos/dpos-user.ts
+++ b/src/dpos/dpos-user.ts
@@ -26,7 +26,7 @@ import {
   ITotalDelegation
 } from '../contracts/dpos2'
 import { selectProtocol } from '../rpc-client-factory'
-import { overrideReadURL } from '../client'
+import { overrideReadUrl } from '../client'
 
 const log = debug('dpos-user')
 
@@ -106,7 +106,7 @@ export class DPOSUser {
       protocols: [{ url: dappchainEndpoint + writerSuffix }]
     })
     const reader = createJSONRPCClient({
-      protocols: [{ url: overrideReadURL(dappchainEndpoint + readerSuffix) as string }]
+      protocols: [{ url: overrideReadUrl(dappchainEndpoint + readerSuffix) }]
     })
 
     const client = new Client(chainId, writer, reader)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -32,7 +32,16 @@ export function hexBN(num: any): BN {
 export function parseUrl(rawUrl: string): URL {
   // In NodeJS 10+ and browsers the URL class is a global object.
   // In earlier NodeJS versions it needs to be imported.
-  if (typeof URL === 'undefined') {
+  let importURL = true
+  try {
+    if (typeof URL !== 'undefined') {
+      importURL = false
+    }
+  } catch (err) {
+    // probably ReferenceError: URL is not defined
+  }
+
+  if (importURL) {
     const url = require('url')
     return new url.URL(rawUrl)
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -32,7 +32,7 @@ export function hexBN(num: any): BN {
 export function parseUrl(rawUrl: string): URL {
   // In NodeJS 10+ and browsers the URL class is a global object.
   // In earlier NodeJS versions it needs to be imported.
-  if (URL === undefined) {
+  if (typeof URL === 'undefined') {
     const url = require('url')
     return new url.URL(rawUrl)
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,3 +28,13 @@ export function sleep(ms: any) {
 export function hexBN(num: any): BN {
   return new BN(num._hex.slice(2), 16)
 }
+
+export function parseUrl(rawUrl: string): URL {
+  // In NodeJS 10+ and browsers the URL class is a global object.
+  // In earlier NodeJS versions it needs to be imported.
+  if (URL === undefined) {
+    const url = require('url')
+    return new url.URL(rawUrl)
+  }
+  return new URL(rawUrl)
+}

--- a/src/plasma-cash/user.ts
+++ b/src/plasma-cash/user.ts
@@ -1,6 +1,8 @@
 import debug from 'debug'
 import BN from 'bn.js'
 import Web3 from 'web3'
+import { ethers, utils } from 'ethers'
+
 import {
   Entity,
   IEntityParams,
@@ -18,11 +20,11 @@ import {
 } from '..'
 import { IPlasmaCoin } from './ethereum-client'
 import { sleep } from '../helpers'
-import { ethers, utils } from 'ethers'
 import { AddressMapper } from '../contracts/address-mapper'
 import { EthersSigner } from '../solidity-helpers'
 import { selectProtocol } from '../rpc-client-factory'
 import { JSONRPCProtocol } from '../internal/json-rpc-client'
+import { overrideReadURL } from '../client'
 
 const debugLog = debug('plasma-cash:user')
 const errorLog = debug('plasma-cash:user:error')
@@ -32,7 +34,6 @@ const ERC20_ABI = [
   'function approve(address spender, uint256 value) public returns (bool)',
   'function allowance(address owner, address spender) public view returns (uint256)'
 ]
-// Helper function to create a user instance.
 
 // User friendly wrapper for all Entity related functions, taking advantage of the database
 export class User extends Entity {
@@ -119,7 +120,7 @@ export class User extends Entity {
       protocols: [{ url: dappchainEndpoint + writerSuffix }]
     })
     const reader = createJSONRPCClient({
-      protocols: [{ url: dappchainEndpoint + readerSuffix }]
+      protocols: [{ url: overrideReadURL(dappchainEndpoint + readerSuffix) as string }]
     })
     const dAppClient = new Client(chainId || 'default', writer, reader)
     let privKey

--- a/src/plasma-cash/user.ts
+++ b/src/plasma-cash/user.ts
@@ -24,7 +24,7 @@ import { AddressMapper } from '../contracts/address-mapper'
 import { EthersSigner } from '../solidity-helpers'
 import { selectProtocol } from '../rpc-client-factory'
 import { JSONRPCProtocol } from '../internal/json-rpc-client'
-import { overrideReadURL } from '../client'
+import { overrideReadUrl } from '../client'
 
 const debugLog = debug('plasma-cash:user')
 const errorLog = debug('plasma-cash:user:error')
@@ -120,7 +120,7 @@ export class User extends Entity {
       protocols: [{ url: dappchainEndpoint + writerSuffix }]
     })
     const reader = createJSONRPCClient({
-      protocols: [{ url: overrideReadURL(dappchainEndpoint + readerSuffix) as string }]
+      protocols: [{ url: overrideReadUrl(dappchainEndpoint + readerSuffix) }]
     })
     const dAppClient = new Client(chainId || 'default', writer, reader)
     let privKey

--- a/src/tests/unit/client-url-override-tests.ts
+++ b/src/tests/unit/client-url-override-tests.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
-import * as url from 'url'
 
 import { Client } from '../../index'
+import { parseUrl } from '../../helpers'
 
 test('Client URL Override', t => {
   try {
@@ -17,8 +17,8 @@ test('Client URL Override', t => {
       client.on('error', (msg: any) => {
         // don't care about connection errors, just want to validate URL override
       })
-      const readUrl = new url.URL(client.readUrl)
-      const writeUrl = new url.URL(client.writeUrl)
+      const readUrl = parseUrl(client.readUrl)
+      const writeUrl = parseUrl(client.writeUrl)
       t.equal(readUrl.hostname, readOnlyHostname, 'Read URL override was applied')
       t.equal(writeUrl.hostname, hostname, 'Write URL was unchanged')
       client.disconnect()

--- a/src/tests/unit/client-url-override-tests.ts
+++ b/src/tests/unit/client-url-override-tests.ts
@@ -1,0 +1,30 @@
+import test from 'tape'
+import * as url from 'url'
+
+import { Client } from '../../index'
+
+test('Client URL Override', t => {
+  try {
+    const hostname = 'plasma.dappchains.com'
+    const readOnlyHostname = 'plasma-readonly.dappchains.com'
+    // Client assumes that if the reader/writer are strings they must be websocket URIs, so only
+    // test those.
+    const clients = [
+      new Client('default', `ws://${hostname}/websocket`, `ws://${hostname}/queryws`),
+      new Client('default', `wss://${hostname}/websocket`, `wss://${hostname}/queryws`)
+    ]
+    for (let client of clients) {
+      client.on('error', (msg: any) => {
+        // don't care about connection errors, just want to validate URL override
+      })
+      const readUrl = new url.URL(client.readUrl)
+      const writeUrl = new url.URL(client.writeUrl)
+      t.equal(readUrl.hostname, readOnlyHostname, 'Read URL override was applied')
+      t.equal(writeUrl.hostname, hostname, 'Write URL was unchanged')
+      client.disconnect()
+    }
+  } catch (err) {
+    t.fail(err)
+  }
+  t.end()
+})

--- a/src/tests/unit_tests.ts
+++ b/src/tests/unit_tests.ts
@@ -1,5 +1,6 @@
 import './unit/address-tests'
 import './unit/big-uint-tests'
+import './unit/client-url-override-tests'
 import './unit/rpc-client-factory-tests'
 import './unit/sparse-merkle-tree-tests'
 import './unit/plasma-cash/database-tests'


### PR DESCRIPTION
Only doing this for the most common code path, override can still be
bypassed if needed.