### PR TITLE
Tweak test for eth_blockNumber to verify the block number is hex encoded

### DIFF
--- a/src/loom-provider.ts
+++ b/src/loom-provider.ts
@@ -385,9 +385,9 @@ export class LoomProvider {
     return accounts
   }
 
-  private async _ethBlockNumber() {
+  private async _ethBlockNumber(): Promise<string> {
     const blockNumber = await this._client.getBlockHeightAsync()
-    return blockNumber
+    return numberToHexLC(+blockNumber)
   }
 
   private async _ethCall(payload: IEthRPCPayload) {

--- a/src/tests/e2e/loom-provider-tests.ts
+++ b/src/tests/e2e/loom-provider-tests.ts
@@ -199,7 +199,8 @@ test('LoomProvider method eth_blockNumber', async t => {
     )
 
     t.equal(ethBlockNumber.id, id, `Id for eth_blockNumber should be equal ${id}`)
-    t.assert(ethBlockNumber.result, 'Number identification should be returned on ethBlockNumber')
+    t.assert(ethBlockNumber.result, 'JSON RPC result should be set')
+    t.equal(ethBlockNumber.result.indexOf('0x'), 0, 'Block number should be hex-encoded')
   } catch (err) {
     console.log(err)
     t.error(err, 'Error found')

--- a/src/tests/e2e/loom-provider-web3-tests.ts
+++ b/src/tests/e2e/loom-provider-web3-tests.ts
@@ -201,6 +201,23 @@ test('LoomProvider + Web3 + Get version', async t => {
   t.end()
 })
 
+test('LoomProvider + Web3 + getBlockNumber', async t => {
+  const { client, web3 } = await newContractAndClient()
+  try {
+    const blockNumber = await web3.eth.getBlockNumber()
+    t.assert(typeof blockNumber === 'number', 'Block number should be a number')
+  } catch (err) {
+    console.log(err)
+  }
+
+  if (client) {
+    client.disconnect()
+  }
+
+  t.end()
+})
+
+
 test('LoomProvider + Web3 + getBlockByNumber', async t => {
   const { client, web3 } = await newContractAndClient()
   try {


### PR DESCRIPTION
`eth_blockNumber` is supposed to return the block number in base 16, prefixed by `0x` as per https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_blocknumber - while LoomProvider was returning it as a base 10 number.