### PR TITLE
Fix LoomCoinTransferGateway.withdrawLoomCoinAsync argument doc

### DIFF
--- a/src/contracts/loomcoin-gateway.ts
+++ b/src/contracts/loomcoin-gateway.ts
@@ -19,7 +19,7 @@ export class LoomCoinTransferGateway extends TransferGateway {
    * Sends a request to the DAppChain Gateway to begin withdrawal of LOOM from the current
    * DAppChain account to an Ethereum account.
    * @param amount Amount to withdraw.
-   * @param mainnetLoomcoinAddress Ethereum address of Ethereum Gateway.
+   * @param mainnetLoomcoinAddress Ethereum address of LOOM coin contract.
    * @param recipient Ethereum address of the account the token should be withdrawn to, if this is
    *                  omitted the Gateway will attempt to use the Address Mapper to retrieve the
    *                  address of the Ethereum account mapped to the current DAppChain account.


### PR DESCRIPTION
Should read "ethereum LOOM contract address" instead of "ethereum gateway address"