### PR TITLE
Added client version to loom provider

### DIFF
--- a/src/loom-provider.ts
+++ b/src/loom-provider.ts
@@ -263,6 +263,7 @@ export class LoomProvider {
     this._ethRPCMethods.set('eth_sendTransaction', this._ethSendTransaction)
     this._ethRPCMethods.set('eth_sign', this._ethSign)
     this._ethRPCMethods.set('net_version', this._netVersion)
+    this._ethRPCMethods.set('web3_clientVersion', this._clientVersion)
   }
 
   /**
@@ -707,6 +708,10 @@ export class LoomProvider {
 
   private _netVersion() {
     return this._netVersionFromChainId
+  }
+
+  private _clientVersion() {
+    return `Loom/loom-js/v${require('../package.json').version}`
   }
 
   // PRIVATE FUNCTIONS IMPLEMENTATIONS

--- a/src/tests/e2e/loom-provider-tests.ts
+++ b/src/tests/e2e/loom-provider-tests.ts
@@ -569,6 +569,28 @@ test('LoomProvider method eth_uninstallFilter', async t => {
   t.end()
 })
 
+test('LoomProvider client version', async t => {
+  const { loomProvider, client } = await newContractAndClient()
+
+  try {
+    const id = 1
+    const clientVersion = await loomProvider.sendAsync({
+      id,
+      method: 'web3_clientVersion'
+    })
+
+    t.assert(/Loom\/loom-js\/v/.test(clientVersion.result), 'Client version should be ok')
+  } catch (err) {
+    t.error(err, 'Error found')
+  }
+
+  if (client) {
+    client.disconnect()
+  }
+
+  t.end()
+})
+
 test('LoomProvider adding custom method', async t => {
   const { loomProvider, from, client } = await newContractAndClient()
 


### PR DESCRIPTION
Adding `web_clientVersion` support for `LoomProvider` retrieving the `package.json.version`
