### PR TITLE
Fix TransferGateway.withdrawalReceiptAsync() to handle missing token contract address

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "Loom Network",
     "url": "https://loomx.io"
   },
-  "version": "1.60.1",
+  "version": "1.60.2",
   "keywords": [
     "blockchain",
     "dappchain"

--- a/src/contracts/transfer-gateway.ts
+++ b/src/contracts/transfer-gateway.ts
@@ -31,8 +31,8 @@ export interface IUnclaimedToken {
 
 export interface IWithdrawalReceipt {
   tokenOwner: Address
-  // Mainnet address of token contract
-  tokenContract: Address
+  // Mainnet address of token contract (NOTE: not set when withdrawing LOOM via Binance Gateway)
+  tokenContract?: Address
   tokenKind: TransferGatewayTokenKind
   // ERC721/X token ID
   tokenId?: BN
@@ -402,9 +402,12 @@ export class TransferGateway extends Contract {
           value = tokenAmount
           break
       }
+
       return {
         tokenOwner: Address.UnmarshalPB(receipt.getTokenOwner()!),
-        tokenContract: Address.UnmarshalPB(receipt.getTokenContract()!),
+        tokenContract: receipt.getTokenContract()
+          ? Address.UnmarshalPB(receipt.getTokenContract()!)
+          : undefined,
         tokenKind,
         tokenId,
         tokenAmount,


### PR DESCRIPTION
Fix `TransferGateway.withdrawalReceiptAsync()` to only unmarshal the token contract address when it's available. When withdrawing LOOM via the Binance Gateway the token contract address is not set on the withdrawal receipt.