### PR TITLE
Fix a couple of issues causing errors TS2307 & TS2416

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "e2e:node": "yarn proto && yarn gen-contract-types && tsc && tape -r dotenv/config dotenv_config_path=./.env.test dist/tests/e2e_tests.js | tap-spec",
     "e2e:browser": "yarn proto && yarn gen-contract-types && tsc && webpack --config webpack.e2e.test.config.js | tap-spec",
     "proto": "node ./scripts/gen-proto.js",
-    "copy-contracts": "node ./scripts/copy-contracts.js",
     "prepublish": "yarn proto && yarn gen-contract-types && yarn build && webpack",
     "gen-contract-types": "typechain \"src/mainnet-contracts/*.json\" --target=ethers --outDir src/mainnet-contracts && node scripts/export-mainnet-contracts-abi.js"
   },

--- a/scripts/export-mainnet-contracts-abi.js
+++ b/scripts/export-mainnet-contracts-abi.js
@@ -1,9 +1,15 @@
-// This script exports the ABI from the TypeChain generated bindings in src/mainnet-contracts/*.ts
-
 const fs = require('fs');
 const path = require('path');
 
+// Export the ABI from the TypeChain generated bindings in src/mainnet-contracts/*.ts
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/ERC20Factory.ts'), '\nexport const abi = _abi;');
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV1Factory.ts'), '\nexport const abi = _abi;');
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV2Factory.ts'), '\nexport const abi = _abi;');
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/ValidatorManagerV2Factory.ts'), '\nexport const abi = _abi;');
+
+// Copy the TypeChain generated d.ts files to dist/mainnet-contracts because the TypeScript compiler doesn't
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ERC20.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/ERC20.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV1.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/EthereumGatewayV1.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV2.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/EthereumGatewayV2.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ValidatorManagerV2.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/ValidatorManagerV2.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/index.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/index.d.ts'));

--- a/scripts/export-mainnet-contracts-abi.js
+++ b/scripts/export-mainnet-contracts-abi.js
@@ -7,6 +7,8 @@ fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGateway
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV2Factory.ts'), '\nexport const abi = _abi;');
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/ValidatorManagerV2Factory.ts'), '\nexport const abi = _abi;');
 
+// Ensure dist/mainnet-contracts exists, otherwise the file copying will fail below
+fs.mkdirSync(path.join(__dirname, '../dist/mainnet-contracts'), { recursive: true });
 // Copy the TypeChain generated d.ts files to dist/mainnet-contracts because the TypeScript compiler doesn't
 fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ERC20.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/ERC20.d.ts'));
 fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV1.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/EthereumGatewayV1.d.ts'));

--- a/scripts/export-mainnet-contracts-abi.js
+++ b/scripts/export-mainnet-contracts-abi.js
@@ -8,10 +8,14 @@ fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGateway
 fs.appendFileSync(path.join(__dirname, '../src/mainnet-contracts/ValidatorManagerV2Factory.ts'), '\nexport const abi = _abi;');
 
 // Ensure dist/mainnet-contracts exists, otherwise the file copying will fail below
-fs.mkdirSync(path.join(__dirname, '../dist/mainnet-contracts'), { recursive: true });
+const contractsDistPath = path.join(__dirname, '../dist/mainnet-contracts');
+if (!fs.existsSync(contractsDistPath)) {
+  fs.mkdirSync(contractsDistPath, { recursive: true });
+}
+
 // Copy the TypeChain generated d.ts files to dist/mainnet-contracts because the TypeScript compiler doesn't
-fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ERC20.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/ERC20.d.ts'));
-fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV1.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/EthereumGatewayV1.d.ts'));
-fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV2.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/EthereumGatewayV2.d.ts'));
-fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ValidatorManagerV2.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/ValidatorManagerV2.d.ts'));
-fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/index.d.ts'), path.join(__dirname, '../dist/mainnet-contracts/index.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ERC20.d.ts'), path.join(contractsDistPath, 'ERC20.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV1.d.ts'), path.join(contractsDistPath, 'EthereumGatewayV1.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/EthereumGatewayV2.d.ts'), path.join(contractsDistPath, 'EthereumGatewayV2.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/ValidatorManagerV2.d.ts'), path.join(contractsDistPath, 'ValidatorManagerV2.d.ts'));
+fs.copyFileSync(path.join(__dirname, '../src/mainnet-contracts/index.d.ts'), path.join(contractsDistPath, 'index.d.ts'));

--- a/src/ethereum-gateways.ts
+++ b/src/ethereum-gateways.ts
@@ -55,7 +55,7 @@ export interface IEthereumGateway {
 }
 
 export class EthereumGatewayV1 implements IEthereumGateway {
-  readonly version = 1
+  readonly version: 1 | 2 = 1
 
   constructor(readonly contract: EthereumGatewayV1Contract) {}
 
@@ -125,7 +125,7 @@ export class EthereumGatewayV1 implements IEthereumGateway {
 }
 
 export class EthereumGatewayV2 implements IEthereumGateway {
-  readonly version = 2
+  readonly version: 1 | 2 = 2
 
   constructor(
     readonly contract: EthereumGatewayV2Contract,


### PR DESCRIPTION
The typings generated by TypeChain for the Gateway Solidity contracts weren't copied to the dist directory and therefore weren't published in the NPM package, this caused compile errors (TS2307) in projects that imported loom-js.

```
node_modules/loom-js/dist/dpos-user.d.ts:7:64 - error TS2307: Cannot find module './mainnet-contracts/EthereumGatewayV2'.

node_modules/loom-js/dist/ethereum-gateways.d.ts:38:14 - error TS2416: Property 'version' in type 'EthereumGatewayV1' is not assignable to the same property in base type 'IEthereumGateway'.
  Type 'number' is not assignable to type 'GatewayVersion'.
```